### PR TITLE
Added --add-this-kernel argument to nvidia installer in download.sh

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -14,7 +14,7 @@ mv NVIDIA-Linux-x86_64-${DRIVER_VERSION}.run /opt/gpu/NVIDIA-Linux-x86_64-${DRIV
 pushd /opt/gpu
 # extract runfile, takes some time, so do ahead of time
 sh /opt/gpu/NVIDIA-Linux-x86_64-${DRIVER_VERSION}.run -x --add-this-kernel
-rm /opt/gpu/NVIDIA-Linux-x86_64-${DRIVER_VERSION}.run
+rm /opt/gpu/NVIDIA-Linux-x86_64-${DRIVER_VERSION}*.run
 popd
 
 # download fabricmanager for nvlink based systems, e.g. multi instance gpu vms.

--- a/download.sh
+++ b/download.sh
@@ -13,7 +13,7 @@ mv NVIDIA-Linux-x86_64-${DRIVER_VERSION}.run /opt/gpu/NVIDIA-Linux-x86_64-${DRIV
 # TODO: reenable this, it saves like 30sec. but it pushes vhd to capacity and starts to fail image pulls :(
 pushd /opt/gpu
 # extract runfile, takes some time, so do ahead of time
-sh /opt/gpu/NVIDIA-Linux-x86_64-${DRIVER_VERSION}.run -x
+sh /opt/gpu/NVIDIA-Linux-x86_64-${DRIVER_VERSION}.run -x --add-this-kernel
 rm /opt/gpu/NVIDIA-Linux-x86_64-${DRIVER_VERSION}.run
 popd
 

--- a/install.sh
+++ b/install.sh
@@ -38,7 +38,7 @@ mount -t overlay overlay -o lowerdir=/usr/lib/x86_64-linux-gnu,upperdir=/tmp/ove
 
 # install nvidia drivers
 pushd /opt/gpu
-/opt/gpu/NVIDIA-Linux-x86_64-${DRIVER_VERSION}/nvidia-installer -s -k=$KERNEL_NAME --log-file-name=${LOG_FILE_NAME} -a --no-drm --dkms --utility-prefix="${GPU_DEST}" --opengl-prefix="${GPU_DEST}"
+/opt/gpu/NVIDIA-Linux-x86_64-${DRIVER_VERSION}-custom/nvidia-installer -s --log-file-name=${LOG_FILE_NAME} -a --no-drm --dkms --utility-prefix="${GPU_DEST}" --opengl-prefix="${GPU_DEST}"
 popd
 
 # move nvidia libs to correct location from temporary overlayfs


### PR DESCRIPTION
Main change is  '--add-this-kernel' to `sh /opt/gpu/NVIDIA-Linux-x86_64-${DRIVER_VERSION}.run -x --add-this-kernel`. From the README in the extracted files:

> 4F. ADDING PRECOMPILED KERNEL INTERFACES TO THE INSTALLER PACKAGE

>When 'nvidia-installer' runs, it searches for a pre-compiled kernel interface
>layer for the target kernel: if one is found, then the complete kernel module
>can be produced by linking the precompiled interface with 'nv-kernel.o',
>instead of needing to compile the kernel interface on the target system.
>'nvidia-installer' includes a feature which allows users to add a precompiled
>interface to the installer package. 

>To use this feature, simply invoke the '.run' installer package with the
>--add-this-kernel option; e.g.

`# sh ./NVIDIA-Linux-x86_64-510.47.03.run --add-this-kernel`

>This will unpack 'NVIDIA-Linux-x86_64-510.47.03.run', compile a kernel
>interface layer for the currently running kernel (use the --kernel-source-path
>and --kernel-output-path options to specify a target kernel other than the
>currently running one), and create a new installer package with the kernel
>interface layer added.

And also:

>Build a precompiled kernel interface for the currently running
>kernel and repackage the .run file to include this newly built
>precompiled kernel interface.  The new .run file will be placed
>in the current directory and the string "-custom" appended
>to its name, unless already present, to distinguish it from the
>original .run file.

So, running `sh /opt/gpu/NVIDIA-Linux-x86_64-${DRIVER_VERSION}.run -x --add-this-kernel` generates `/opt/gpu/NVIDIA-Linux-x86_64-${DRIVER_VERSION}-custom.run`, which contains the precompiled kernel layer for the currently running kernel.

I also removed the -k command since it seems to disable the use of precompiled interfaces.

>-k KERNEL-NAME, --kernel-name=KERNEL-NAME
>      Build and install the NVIDIA kernel module for the non-running kernel specified by KERNEL-NAME (KERNEL->NAME should be the output of `uname -r` when the target kernel is actually running).  This option implies '--no->precompiled-interface'.  If the options '--kernel-install-path' and '--kernel-source-path' are not given, then they will >be inferred from KERNEL-NAME; eg: '/lib/modules/KERNEL-NAME/kernel/drivers/video/' and '/lib/modules/KERNEL->NAME/build/', respectively.

 >-n, --no-precompiled-interface
>      Disable use of precompiled kernel interfaces.