### PR TITLE
feat: update base image of driver container to 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG distro=18.04
+ARG distro=22.04
 
 FROM mcr.microsoft.com/mirror/docker/library/ubuntu:${distro} as gpu
 


### PR DESCRIPTION
Bumping base image to 22.04 from 18.04, to have a better security coverage (CVE fixes) and  get latest features. 