### PR TITLE
fix: remove apt-get linux headers

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,10 +19,6 @@ echo "Open gridd: $open_gridd"
 
 set -euo pipefail
 
-install_linux_headers() {
-  apt install -y linux-headers-$(uname -r) --no-install-recommends
-}
-
 use_package_manager_with_retries wait_for_apt_locks install_linux_headers 10 3
 
 # install cached nvidia debian packages for container runtime compatibility

--- a/install.sh
+++ b/install.sh
@@ -19,8 +19,6 @@ echo "Open gridd: $open_gridd"
 
 set -euo pipefail
 
-use_package_manager_with_retries wait_for_apt_locks 10 3
-
 # install cached nvidia debian packages for container runtime compatibility
 install_cached_nvidia_packages() {
 for apt_package in $NVIDIA_PACKAGES; do

--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,7 @@ echo "Open gridd: $open_gridd"
 
 set -euo pipefail
 
-use_package_manager_with_retries wait_for_apt_locks install_linux_headers 10 3
+use_package_manager_with_retries wait_for_apt_locks 10 3
 
 # install cached nvidia debian packages for container runtime compatibility
 install_cached_nvidia_packages() {


### PR DESCRIPTION
Remove this apt-get call since linux headers should already be on the VHD -  https://github.com/Azure/AgentBaker/blob/master/vhdbuilder/release-notes/AKSUbuntu/gen2/2204containerd/202402.07.0.txt#L626 and all egress calls need to be removed from provisioning. 

steps to test - 
created a cluster without the gpu driver install
```
az aks nodepool add --resource-group alison-dpd-rg --cluster-name egress-gpu-testing --name egressgpu --node-count 1 --skip-gpu-driver-install --node-vm-size Standard_NC6s_v3 --node-taints sku=gpu:NoSchedule --enable-cluster-autoscaler --min-count 1 --max-count 3
```

made a gpu node
```
alisonburgess@Alisons-Macbook-Pro---Work ~ % kubectl get nodes
aks-egressgpu-12007650-vmss000000   Ready    agent   2m54s   v1.27.9
```

nodeshell into the node and verify that nvidia-smi is not there
```
nodeshell aks-egressgpu-12007650-vmss000000
nvidia-smi
Command 'nvidia-smi' not found, but can be installed with:
```
steps from the readme
```
# mkdir -p /opt/{actions,gpu}
# ctr image pull docker.io/alburgess/aks-gpu:latest
# ctr run --privileged --net-host --with-ns pid:/proc/1/ns/pid --mount type=bind,src=/opt/gpu,dst=/mnt/gpu,options=rbind --mount type=bind,src=/opt/actions,dst=/mnt/actions,options=rbind -t docker.io/alburgess/aks-gpu:latest gpuinstall /entrypoint.sh install
 # nvidia-smi
Wed Feb 28 01:31:28 2024       
+-----------------------------------------------------------------------------+
| NVIDIA-SMI 515.65.01    Driver Version: 515.65.01    CUDA Version: 11.7     |
|-------------------------------+----------------------+----------------------+
| GPU  Name        Persistence-M| Bus-Id        Disp.A | Volatile Uncorr. ECC |
| Fan  Temp  Perf  Pwr:Usage/Cap|         Memory-Usage | GPU-Util  Compute M. |
|                               |                      |               MIG M. |
|===============================+======================+======================|
|   0  Tesla V100-PCIE...  On   | 00000001:00:00.0 Off |                  Off |
| N/A   27C    P0    25W / 250W |      0MiB / 16384MiB |      0%      Default |
|                               |                      |                  N/A |
+-------------------------------+----------------------+----------------------+
                                                                               
+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|  No running processes found                                                 |
+-----------------------------------------------------------------------------+

```

