### PR TITLE
Publish 550.54.15 CUDA drivers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        driver_version: ["470.82.01", "510.47.03", "515.65.01", "525.85.12", "535.54.03"]
+        driver_version: ["470.82.01", "510.47.03", "515.65.01", "525.85.12", "535.54.03", "550.54.15"]
         driver_kind: ["cuda"]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        driver_version: ["470.82.01", "510.47.03", "515.65.01", "525.85.12", "535.161.08", "550.54.15"]
+        driver_version: ["470.82.01", "510.47.03", "515.65.01", "525.85.12", "535.161.08", "550.54.15"] # TODO: remove older versions
         driver_kind: ["cuda"]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        driver_version: ["470.82.01", "510.47.03", "515.65.01", "525.85.12", "535.161.08", "550.54.15"] # TODO: remove older versions
+        driver_version: ["470.82.01", "510.47.03", "515.65.01", "525.85.12", "535.54.03", "550.54.15"] # TODO: remove older versions
         driver_kind: ["cuda"]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        driver_version: ["470.82.01", "510.47.03", "515.65.01", "525.85.12", "535.54.03", "550.54.15"]
+        driver_version: ["470.82.01", "510.47.03", "515.65.01", "525.85.12", "535.161.08", "550.54.15"]
         driver_kind: ["cuda"]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        driver_version: ["470.82.01", "510.47.03", "515.65.01", "525.85.12", "535.54.03", "535.161.08", "550.54.15"]
+        driver_version: ["470.82.01", "510.47.03", "515.65.01", "525.85.12", "535.54.03", "550.54.15"]
         driver_kind: ["cuda"]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        driver_version: ["470.82.01", "510.47.03", "515.65.01", "525.85.12", "535.54.03"]
+        driver_version: ["470.82.01", "510.47.03", "515.65.01", "525.85.12", "535.54.03", "550.54.15"]
         driver_kind: ["cuda"]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        driver_version: ["470.82.01", "510.47.03", "515.65.01", "525.85.12", "535.54.03", "550.54.15"]
+        driver_version: ["470.82.01", "510.47.03", "515.65.01", "525.85.12", "535.54.03", "535.161.08", "550.54.15"]
         driver_kind: ["cuda"]
     steps:
       - uses: actions/checkout@v2

--- a/justfile
+++ b/justfile
@@ -9,7 +9,7 @@ grid_470_driver := "470.82.01"
 cuda_510_driver := "510.47.03"
 cuda_470_driver := "470.82.01"
 cuda_515_driver := "515.65.01"
-cuda_535_driver := "535.154.05"
+cuda_535_driver := "535.161.08"
 cuda_550_driver := "550.54.15"
 registry := "docker.io/alexeldeib"
 

--- a/justfile
+++ b/justfile
@@ -10,11 +10,12 @@ cuda_510_driver := "510.47.03"
 cuda_470_driver := "470.82.01"
 cuda_515_driver := "515.65.01"
 cuda_535_driver := "535.154.05"
+cuda_550_driver := "550.54.15"
 registry := "docker.io/alexeldeib"
 
 default:
 
-pushallcuda: (pushcuda cuda_535_driver) (pushcuda cuda_515_driver) (pushcuda cuda_510_driver) (pushcuda cuda_470_driver) 
+pushallcuda: (pushcuda cuda_550_driver) (pushcuda cuda_535_driver) (pushcuda cuda_515_driver) (pushcuda cuda_510_driver) (pushcuda cuda_470_driver) 
 
 pushallgrid: (pushgrid grid_510_driver grid_510_url grid_535_driver) #(pushgrid grid_470_driver grid_470_url)
 


### PR DESCRIPTION
For modpost error, new features and other fixes.

Release notes for the 550.54.15 driver: https://docs.nvidia.com/datacenter/tesla/tesla-release-notes-550-54-15/index.html

Modpost issue tracking:
https://forums.developer.nvidia.com/t/linux-6-7-3-545-29-06-550-40-07-error-modpost-gpl-incompatible-module-nvidia-ko-uses-gpl-only-symbol-rcu-read-lock/280908/4