### PR TITLE
Update variable name to FABRIC_MANAGER_VERSION for installation function

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -28,17 +28,17 @@ popd
 
 
 install_fabric_manager () {
-    local driver_ver="${DRIVER_VERSION}"
+    local fabric_manager_version="${DRIVER_VERSION}"
     if [[ "${DRIVER_VERSION}" == "535.161.08" ]]; then
-      local driver_ver="535.104.05"
-      # Temporary as latest fabric manager version here is not the same as the driver version. https://developer.download.nvidia.com/compute/cuda/redist/fabricmanager/linux-x86_64/
-      curl -fsSLO https://developer.download.nvidia.com/compute/cuda/redist/fabricmanager/linux-x86_64/fabricmanager-linux-x86_64-${driver_ver}-archive.tar.xz
+      local fabric_manager_version="535.104.05"
+      # TODO Temporary as latest fabric manager version here is not the same as the driver version. https://developer.download.nvidia.com/compute/cuda/redist/fabricmanager/linux-x86_64/
+      curl -fsSLO https://developer.download.nvidia.com/compute/cuda/redist/fabricmanager/linux-x86_64/fabricmanager-linux-x86_64-${fabric_manager_version}-archive.tar.xz
     else
       curl -fsSLO https://developer.download.nvidia.com/compute/cuda/redist/fabricmanager/linux-x86_64/fabricmanager-linux-x86_64-${DRIVER_VERSION}-archive.tar.xz
     fi
-    tar -xvf fabricmanager-linux-x86_64-${driver_ver}-archive.tar.xz
-    mv fabricmanager-linux-x86_64-${driver_ver}-archive /opt/gpu/fabricmanager-linux-x86_64-${driver_ver}
-    mv /opt/gpu/fm_run_package_installer.sh /opt/gpu/fabricmanager-linux-x86_64-${driver_ver}/sbin/fm_run_package_installer.sh
+    tar -xvf fabricmanager-linux-x86_64-${fabric_manager_version}-archive.tar.xz
+    mv fabricmanager-linux-x86_64-${fabric_manager_version}-archive /opt/gpu/fabricmanager-linux-x86_64-${fabric_manager_version}
+    mv /opt/gpu/fm_run_package_installer.sh /opt/gpu/fabricmanager-linux-x86_64-${fabric_manager_version}/sbin/fm_run_package_installer.sh
 }
 
 if [[ "${DRIVER_KIND}" == "cuda" ]]; then

--- a/download.sh
+++ b/download.sh
@@ -28,17 +28,17 @@ popd
 
 
 install_fabric_manager () {
-    local fabric_manager_version="${DRIVER_VERSION}"
+    FABRIC_MANAGER_VERSION="${DRIVER_VERSION}"
     if [[ "${DRIVER_VERSION}" == "535.161.08" ]]; then
-      local fabric_manager_version="535.104.05"
+      FABRIC_MANAGER_VERSION="535.104.05"
       # TODO Temporary as latest fabric manager version here is not the same as the driver version. https://developer.download.nvidia.com/compute/cuda/redist/fabricmanager/linux-x86_64/
-      curl -fsSLO https://developer.download.nvidia.com/compute/cuda/redist/fabricmanager/linux-x86_64/fabricmanager-linux-x86_64-${fabric_manager_version}-archive.tar.xz
+      curl -fsSLO https://developer.download.nvidia.com/compute/cuda/redist/fabricmanager/linux-x86_64/fabricmanager-linux-x86_64-${FABRIC_MANAGER_VERSION}-archive.tar.xz
     else
-      curl -fsSLO https://developer.download.nvidia.com/compute/cuda/redist/fabricmanager/linux-x86_64/fabricmanager-linux-x86_64-${DRIVER_VERSION}-archive.tar.xz
+      curl -fsSLO https://developer.download.nvidia.com/compute/cuda/redist/fabricmanager/linux-x86_64/fabricmanager-linux-x86_64-${FABRIC_MANAGER_VERSION}-archive.tar.xz
     fi
-    tar -xvf fabricmanager-linux-x86_64-${fabric_manager_version}-archive.tar.xz
-    mv fabricmanager-linux-x86_64-${fabric_manager_version}-archive /opt/gpu/fabricmanager-linux-x86_64-${fabric_manager_version}
-    mv /opt/gpu/fm_run_package_installer.sh /opt/gpu/fabricmanager-linux-x86_64-${fabric_manager_version}/sbin/fm_run_package_installer.sh
+    tar -xvf fabricmanager-linux-x86_64-${FABRIC_MANAGER_VERSION}-archive.tar.xz
+    mv fabricmanager-linux-x86_64-${FABRIC_MANAGER_VERSION}-archive /opt/gpu/fabricmanager-linux-x86_64-${FABRIC_MANAGER_VERSION}
+    mv /opt/gpu/fm_run_package_installer.sh /opt/gpu/fabricmanager-linux-x86_64-${FABRIC_MANAGER_VERSION}/sbin/fm_run_package_installer.sh
 }
 
 if [[ "${DRIVER_KIND}" == "cuda" ]]; then

--- a/download.sh
+++ b/download.sh
@@ -32,10 +32,10 @@ install_fabric_manager () {
     if [[ "${DRIVER_VERSION}" == "535.161.08" ]]; then
       FABRIC_MANAGER_VERSION="535.104.05"
       # TODO Temporary as latest fabric manager version here is not the same as the driver version. https://developer.download.nvidia.com/compute/cuda/redist/fabricmanager/linux-x86_64/
-      curl -fsSLO https://developer.download.nvidia.com/compute/cuda/redist/fabricmanager/linux-x86_64/fabricmanager-linux-x86_64-${FABRIC_MANAGER_VERSION}-archive.tar.xz
-    else
-      curl -fsSLO https://developer.download.nvidia.com/compute/cuda/redist/fabricmanager/linux-x86_64/fabricmanager-linux-x86_64-${FABRIC_MANAGER_VERSION}-archive.tar.xz
     fi
+
+    curl -fsSLO https://developer.download.nvidia.com/compute/cuda/redist/fabricmanager/linux-x86_64/fabricmanager-linux-x86_64-${FABRIC_MANAGER_VERSION}-archive.tar.xz
+
     tar -xvf fabricmanager-linux-x86_64-${FABRIC_MANAGER_VERSION}-archive.tar.xz
     mv fabricmanager-linux-x86_64-${FABRIC_MANAGER_VERSION}-archive /opt/gpu/fabricmanager-linux-x86_64-${FABRIC_MANAGER_VERSION}
     mv /opt/gpu/fm_run_package_installer.sh /opt/gpu/fabricmanager-linux-x86_64-${FABRIC_MANAGER_VERSION}/sbin/fm_run_package_installer.sh


### PR DESCRIPTION
Clearer name for the function to install fabric manager, as fabric manager version and the driver version are different in some cases. Need to check with Nvidia if that will be the case going forward or if it is a temporary gap.