### PR TITLE
chore: fix TODO by using new download URL for fabric manager

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -28,17 +28,10 @@ popd
 
 
 install_fabric_manager () {
-    FABRIC_MANAGER_VERSION="${DRIVER_VERSION}"
-    if [[ "${DRIVER_VERSION}" == "535.161.08" ]]; then
-      FABRIC_MANAGER_VERSION="535.104.05"
-      # TODO Temporary as latest fabric manager version here is not the same as the driver version. https://developer.download.nvidia.com/compute/cuda/redist/fabricmanager/linux-x86_64/
-    fi
-
-    curl -fsSLO https://developer.download.nvidia.com/compute/cuda/redist/fabricmanager/linux-x86_64/fabricmanager-linux-x86_64-${FABRIC_MANAGER_VERSION}-archive.tar.xz
-
-    tar -xvf fabricmanager-linux-x86_64-${FABRIC_MANAGER_VERSION}-archive.tar.xz
-    mv fabricmanager-linux-x86_64-${FABRIC_MANAGER_VERSION}-archive /opt/gpu/fabricmanager-linux-x86_64-${FABRIC_MANAGER_VERSION}
-    mv /opt/gpu/fm_run_package_installer.sh /opt/gpu/fabricmanager-linux-x86_64-${FABRIC_MANAGER_VERSION}/sbin/fm_run_package_installer.sh
+    curl -fsSLO https://developer.download.nvidia.com/compute/nvidia-driver/redist/fabricmanager/linux-x86_64/fabricmanager-linux-x86_64-${DRIVER_VERSION}-archive.tar.xz
+    tar -xvf fabricmanager-linux-x86_64-${DRIVER_VERSION}-archive.tar.xz
+    mv fabricmanager-linux-x86_64-${DRIVER_VERSION}-archive /opt/gpu/fabricmanager-linux-x86_64-${DRIVER_VERSION}
+    mv /opt/gpu/fm_run_package_installer.sh /opt/gpu/fabricmanager-linux-x86_64-${DRIVER_VERSION}/sbin/fm_run_package_installer.sh
 }
 
 if [[ "${DRIVER_KIND}" == "cuda" ]]; then


### PR DESCRIPTION
The NVIDIA folks gave us the new URL where the binary with the matching installer with the same driver version can be found, reverting to using the driver_version for the fabric_manager version. 