### PR TITLE
Remove older CUDA driver versions (470, 510, 515, 525)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        driver_version: ["470.82.01", "510.47.03", "515.65.01", "525.85.12", "535.161.08", "550.54.15"] # TODO: remove older versions
+        driver_version: ["535.161.08", "550.54.15"]
         driver_kind: ["cuda"]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        driver_version: ["470.82.01", "510.47.03", "515.65.01", "525.85.12", "535.161.08", "550.54.15"]
+        driver_version: ["535.161.08", "550.54.15"]
         driver_kind: ["cuda"]
     steps:
       - uses: actions/checkout@v2

--- a/justfile
+++ b/justfile
@@ -6,16 +6,13 @@ grid_535_driver := "535.154.05"
 grid_510_driver := "510.73.08" 
 grid_470_driver := "470.82.01" 
 
-cuda_510_driver := "510.47.03"
-cuda_470_driver := "470.82.01"
-cuda_515_driver := "515.65.01"
 cuda_535_driver := "535.161.08"
 cuda_550_driver := "550.54.15"
 registry := "docker.io/alexeldeib"
 
 default:
 
-pushallcuda: (pushcuda cuda_550_driver) (pushcuda cuda_535_driver) (pushcuda cuda_515_driver) (pushcuda cuda_510_driver) (pushcuda cuda_470_driver) 
+pushallcuda: (pushcuda cuda_550_driver) (pushcuda cuda_535_driver)
 
 pushallgrid: (pushgrid grid_510_driver grid_510_url grid_535_driver) #(pushgrid grid_470_driver grid_470_url)
 


### PR DESCRIPTION
These CUDA driver versions are not being used in Agentbaker, in newer versions and can be removed. 