### PR TITLE
Update GRID to 535.161.08 for GPL symbol/kernel compat fix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,9 +129,9 @@ jobs:
       runs-on: ubuntu-latest
       strategy:
         matrix:
-          driver_version: ["535.154.05"]
+          driver_version: ["535.161.08"]
           driver_kind: ["grid"]
-          driver_url: ["https://download.microsoft.com/download/1/4/4/14450d0e-a3f2-4b0a-9bb4-a8e729e986c4/NVIDIA-Linux-x86_64-535.154.05-grid-azure.run"]
+          driver_url: ["https://download.microsoft.com/download/8/d/a/8da4fb8e-3a9b-4e6a-bc9a-72ff64d7a13c/NVIDIA-Linux-x86_64-535.161.08-grid-azure.run"]
       steps:
         - uses: actions/checkout@v2
           with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -156,9 +156,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        driver_version: ["535.154.05"]
+        driver_version: ["535.161.08"]
         driver_kind: ["grid"]
-        driver_url: ["https://download.microsoft.com/download/1/4/4/14450d0e-a3f2-4b0a-9bb4-a8e729e986c4/NVIDIA-Linux-x86_64-535.154.05-grid-azure.run"]
+        driver_url: ["https://download.microsoft.com/download/8/d/a/8da4fb8e-3a9b-4e6a-bc9a-72ff64d7a13c/NVIDIA-Linux-x86_64-535.161.08-grid-azure.run"]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 grid_470_url    := "https://download.microsoft.com/download/a/3/c/a3c078a0-e182-4b61-ac9b-ac011dc6ccf4/NVIDIA-Linux-x86_64-470.82.01-grid-azure.run"
 grid_510_url    := "https://download.microsoft.com/download/6/2/5/625e22a0-34ea-4d03-8738-a639acebc15e/NVIDIA-Linux-x86_64-510.73.08-grid-azure.run"
-grid_535_url    := "https://download.microsoft.com/download/1/4/4/14450d0e-a3f2-4b0a-9bb4-a8e729e986c4/NVIDIA-Linux-x86_64-535.161.08-grid-azure.run"
+grid_535_url    := "https://download.microsoft.com/download/8/d/a/8da4fb8e-3a9b-4e6a-bc9a-72ff64d7a13c/NVIDIA-Linux-x86_64-535.161.08-grid-azure.run"
 
 grid_535_driver := "535.161.08"
 grid_510_driver := "510.73.08" 

--- a/justfile
+++ b/justfile
@@ -1,8 +1,8 @@
 grid_470_url    := "https://download.microsoft.com/download/a/3/c/a3c078a0-e182-4b61-ac9b-ac011dc6ccf4/NVIDIA-Linux-x86_64-470.82.01-grid-azure.run"
 grid_510_url    := "https://download.microsoft.com/download/6/2/5/625e22a0-34ea-4d03-8738-a639acebc15e/NVIDIA-Linux-x86_64-510.73.08-grid-azure.run"
-grid_535_url    := "https://download.microsoft.com/download/1/4/4/14450d0e-a3f2-4b0a-9bb4-a8e729e986c4/NVIDIA-Linux-x86_64-535.154.05-grid-azure.run"
+grid_535_url    := "https://download.microsoft.com/download/1/4/4/14450d0e-a3f2-4b0a-9bb4-a8e729e986c4/NVIDIA-Linux-x86_64-535.161.08-grid-azure.run"
 
-grid_535_driver := "535.154.05"
+grid_535_driver := "535.161.08"
 grid_510_driver := "510.73.08" 
 grid_470_driver := "470.82.01" 
 


### PR DESCRIPTION
This is to fix this issue affecting Linux kernels 5.15.1063+ versions. 

It's a new driver based on vGPU 16.5.

Modpost issue tracking:
https://forums.developer.nvidia.com/t/linux-6-7-3-545-29-06-550-40-07-error-modpost-gpl-incompatible-module-nvidia-ko-uses-gpl-only-symbol-rcu-read-lock/280908/4