### PR TITLE
Update NVIDIA Container Toolkit installation

### DIFF
--- a/download.sh
+++ b/download.sh
@@ -9,7 +9,7 @@ pushd "$workdir" || exit
 
 if [[ "${DRIVER_KIND}" == "cuda" ]]; then
     RUNFILE="NVIDIA-Linux-x86_64-${DRIVER_VERSION}"
-    curl -fsSLO https://us.download.nvidia.com/tesla/${DRIVER_VERSION}/${RUNFILE}.run 
+    curl -fsSLO https://us.download.nvidia.com/tesla/${DRIVER_VERSION}/${RUNFILE}.run
 elif [[ "${DRIVER_KIND}" == "grid" ]]; then
     RUNFILE="NVIDIA-Linux-x86_64-${DRIVER_VERSION}-grid-azure"
     curl -fsSLO "${DRIVER_URL}"
@@ -41,10 +41,10 @@ fi
 
 
 # configure nvidia apt repo to cache packages
-curl -fsSLO https://nvidia.github.io/nvidia-docker/gpgkey
+curl -fsSLO https://nvidia.github.io/libnvidia-container/gpgkey
 gpg --dearmor -o aptnvidia.gpg gpgkey
 mv aptnvidia.gpg /etc/apt/trusted.gpg.d/aptnvidia.gpg
-curl -fsSL https://nvidia.github.io/nvidia-docker/ubuntu${VERSION_ID}/nvidia-docker.list -o /etc/apt/sources.list.d/nvidia-docker.list
+curl -fsSL https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list -o /etc/apt/sources.list.d/nvidia-container-toolkit.list
 
 apt update
 
@@ -53,17 +53,6 @@ for apt_package in $NVIDIA_PACKAGES; do
     apt-get download ${apt_package}=${NVIDIA_CONTAINER_TOOLKIT_VER}*
     mv ${apt_package}_${NVIDIA_CONTAINER_TOOLKIT_VER}* /opt/gpu
 done
-apt-get download nvidia-container-runtime=${NVIDIA_CONTAINER_RUNTIME_VERSION}*
-
-# move debs to permanent cache
-mv nvidia-container-runtime_${NVIDIA_CONTAINER_RUNTIME_VERSION}* /opt/gpu
-
-# nvidia-docker2 for docker runtime
-apt-get download nvidia-docker2=${NVIDIA_DOCKER_VERSION}
-mkdir -p /tmp/nvidia-docker2
-dpkg-deb -R ./nvidia-docker2_${NVIDIA_DOCKER_VERSION}_all.deb /tmp/nvidia-docker2
-mkdir -p /opt/gpu/nvidia-docker2_${NVIDIA_DOCKER_VERSION}
-cp -r /tmp/nvidia-docker2/usr/* /opt/gpu/nvidia-docker2_${NVIDIA_DOCKER_VERSION}/
 
 popd || exit
 rm -r "$workdir"

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,6 @@ install_cached_nvidia_packages() {
 for apt_package in $NVIDIA_PACKAGES; do
     dpkg -i --force-overwrite /opt/gpu/${apt_package}_${NVIDIA_CONTAINER_TOOLKIT_VER}*
 done
-dpkg -i --force-overwrite /opt/gpu/nvidia-container-runtime_${NVIDIA_CONTAINER_RUNTIME_VERSION}*
 }
 
 use_package_manager_with_retries wait_for_dpkg_lock install_cached_nvidia_packages 10 3
@@ -80,7 +79,7 @@ fi
 
 # configure system to know about nvidia lib paths
 echo "${GPU_DEST}/lib64" > /etc/ld.so.conf.d/nvidia.conf
-ldconfig 
+ldconfig
 
 # unmount, cleanup
 set +e
@@ -95,15 +94,13 @@ nvidia-modprobe -u -c0
 
 # configure persistence daemon
 # decreases latency for later driver loads
-# reduces nvidia-smi invocation time 10x from 30 to 2 sec 
+# reduces nvidia-smi invocation time 10x from 30 to 2 sec
 # notable on large VM sizes with multiple GPUs
 # especially when nvidia-smi process is in CPU cgroup
 cp /opt/gpu/nvidia-persistenced.service /etc/systemd/system/nvidia-persistenced.service
 systemctl enable nvidia-persistenced.service
 systemctl restart nvidia-persistenced.service
 nvidia-smi
-
-cp -r  /opt/gpu/nvidia-docker2_${NVIDIA_DOCKER_VERSION}/* /usr/
 
 # install fabricmanager for nvlink based systems
 if [[ "${DRIVER_KIND}" == "cuda" ]]; then


### PR DESCRIPTION
Update the installation of the components of the NVIDIA Container Toolkit to use the distribution-independent URL and remove references to deprecated meta pacakges nvidia-container-runtime and nvidia-docker2.