### PR TITLE
refactor: move GPU drivers to config and refactor pipelines for CUDA driver

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,9 +21,9 @@ jobs:
       - name: Load config
         id: set_config
         run: |
-          echo "cuda_version=$(yq e '.cuda.version' ../../driver_config.yml)" >> $GITHUB_OUTPUT
-          echo "grid_version=$(yq e '.grid.version' ../../driver_config.yml)" >> $GITHUB_OUTPUT
-          echo "grid_url=$(yq e '.grid.url' ../../driver_config.yml)" >> $GITHUB_OUTPUT 
+          echo "cuda_version=$(yq e '.cuda.version' driver_config.yml)" >> $GITHUB_OUTPUT
+          echo "grid_version=$(yq e '.grid.version' driver_config.yml)" >> $GITHUB_OUTPUT
+          echo "grid_url=$(yq e '.grid.url' driver_config.yml)" >> $GITHUB_OUTPUT 
   cuda:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,9 +21,15 @@ jobs:
       - name: Load config
         id: set_config
         run: |
-          echo "cuda_version=$(yq e '.cuda.version' driver_config.yml)" >> $GITHUB_OUTPUT
-          echo "grid_version=$(yq e '.grid.version' driver_config.yml)" >> $GITHUB_OUTPUT
-          echo "grid_url=$(yq e '.grid.url' driver_config.yml)" >> $GITHUB_OUTPUT 
+          CUDA_VERSION=$(yq e '.cuda.version' driver_config.yml)
+          GRID_VERSION=$(yq e '.grid.version' driver_config.yml)
+          GRID_URL=$(yq e '.grid.url' driver_config.yml)
+          echo "CUDA_VERSION=$CUDA_VERSION"
+          echo "GRID_VERSION=$GRID_VERSION"
+          echo "GRID_URL=$GRID_URL"
+          echo "::set-output name=cuda_version::$CUDA_VERSION"
+          echo "::set-output name=grid_version::$GRID_VERSION"
+          echo "::set-output name=grid_url::$GRID_URL"
   cuda:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
           set -x
           echo "tag is: "
           echo ${{ steps.semver.outputs.version }}
-          docker buildx build --build-arg DRIVER_KIND=${{ matrix.driver_kind }} --build-arg DRIVER_VERSION=${{ matrix.driver_version }} --cache-from=type=local,src=/tmp/.buildx-cache --cache-to=type=local,dest=/tmp/.buildx-cache-new --output=type=docker -t ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-gpu:${{ steps.semver.outputs.version }} .
+          docker buildx build --build-arg DRIVER_KIND=${{ matrix.driver_kind }} --build-arg DRIVER_VERSION=${{ steps.load_config.outputs.cuda_version }} --cache-from=type=local,src=/tmp/.buildx-cache --cache-to=type=local,dest=/tmp/.buildx-cache-new --output=type=docker -t ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-gpu:${{ steps.semver.outputs.version }} .
           docker images
       - name: Move cache
         run: |
@@ -67,9 +67,9 @@ jobs:
           uses: actions/cache@v2
           with:
             path: /tmp/.buildx-cache
-            key: ${{ runner.os }}-buildx-${{ matrix.driver_kind}}-${{ matrix.driver_version }}-${{ github.sha }}
+            key: ${{ runner.os }}-buildx-${{ matrix.driver_kind}}-${{ steps.load_config.outputs.cuda_version }}-${{ github.sha }}
             restore-keys: |
-              ${{ runner.os }}-buildx-${{ matrix.driver_kind}}-${{ matrix.driver_version }}
+              ${{ runner.os }}-buildx-${{ matrix.driver_kind}}-${{ steps.load_config.outputs.cuda_version }}
         - uses: paulhatch/semantic-version@v5.0.0-alpha2
           with:
             bump_each_commit: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,40 +6,21 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  load_config:
-    runs-on: ubuntu-latest
-    outputs:
-      cuda_version: ${{ steps.set_config.outputs.cuda_version }}
-      grid_version: ${{ steps.set_config.outputs.grid_version }}
-      grid_url: ${{ steps.set_config.outputs.grid_url }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install yq
-        run: |
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-          sudo chmod a+x /usr/local/bin/yq
-      - name: Load config
-        id: set_config
-        run: |
-          CUDA_VERSION=$(yq e '.cuda.version' driver_config.yml)
-          GRID_VERSION=$(yq e '.grid.version' driver_config.yml)
-          GRID_URL=$(yq e '.grid.url' driver_config.yml)
-          echo "CUDA_VERSION=$CUDA_VERSION"
-          echo "GRID_VERSION=$GRID_VERSION"
-          echo "GRID_URL=$GRID_URL"
-          echo "::set-output name=cuda_version::$CUDA_VERSION"
-          echo "::set-output name=grid_version::$GRID_VERSION"
-          echo "::set-output name=grid_url::$GRID_URL"
   cuda:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        driver_version: ["${{ needs.load_config.outputs.cuda_version }}"]
         driver_kind: ["cuda"]
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Load CUDA config
+        id: load_config
+        run: |
+          cuda_version=$(yq e '.cuda.version' driver_config.yml)
+          echo "CUDA_VERSION=$cuda_version"
+          echo "cuda_version=$cuda_version" >> $GITHUB_OUTPUT
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Cache Docker layers
@@ -52,7 +33,7 @@ jobs:
       - uses: paulhatch/semantic-version@v5.0.0-alpha2
         with:
           bump_each_commit: false
-          version_format: "${{ matrix.driver_kind}}-${{ matrix.driver_version }}-sha-${GITHUB_SHA:0:6}"
+          version_format: "cuda-${{ steps.load_config.outputs.cuda_version }}-sha-${GITHUB_SHA:0:6}"
         id: semver
       - name: 'Check version'
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,25 @@ on:
       - main
   workflow_dispatch: {}
 
-jobs: 
+jobs:
+  load_config:
+    runs-on: ubuntu-latest
+    outputs:
+      cuda_version: ${{ steps.set_config.outputs.cuda_version }}
+      grid_version: ${{ steps.set_config.outputs.grid_version }}
+      grid_url: ${{ steps.set_config.outputs.grid_url }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod a+x /usr/local/bin/yq
+      - name: Load config
+        id: set_config
+        run: |
+          echo "cuda_version=$(yq e '.cuda.version' ../../driver_config.yml)" >> $GITHUB_OUTPUT
+          echo "grid_version=$(yq e '.grid.version' ../../driver_config.yml)" >> $GITHUB_OUTPUT
+          echo "grid_url=$(yq e '.grid.url' ../../driver_config.yml)" >> $GITHUB_OUTPUT 
   cuda:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        driver_version: ["550.90.07"]
+        driver_version: ["${{ needs.load_config.outputs.cuda_version }}"]
         driver_kind: ["cuda"]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,31 +9,6 @@ permissions:
   contents: read
 
 jobs:
-  load_config:
-    runs-on: ubuntu-latest
-    outputs:
-      cuda_version: ${{ steps.set_config.outputs.cuda_version }}
-      grid_version: ${{ steps.set_config.outputs.grid_version }}
-      grid_url: ${{ steps.set_config.outputs.grid_url }}
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install yq
-        run: |
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-          sudo chmod a+x /usr/local/bin/yq
-      - name: Load config
-        id: set_config
-        run: |
-          CUDA_VERSION=$(yq e '.cuda.version' driver_config.yml)
-          GRID_VERSION=$(yq e '.grid.version' driver_config.yml)
-          GRID_URL=$(yq e '.grid.url' driver_config.yml)
-          echo "CUDA_VERSION=$CUDA_VERSION"
-          echo "GRID_VERSION=$GRID_VERSION"
-          echo "GRID_URL=$GRID_URL"
-          echo "::set-output name=cuda_version::$CUDA_VERSION"
-          echo "::set-output name=grid_version::$GRID_VERSION"
-          echo "::set-output name=grid_url::$GRID_URL"
- 
   cuda:
     runs-on: ubuntu-latest
     strategy:
@@ -41,19 +16,12 @@ jobs:
         driver_version: ["${{ needs.load_config.outputs.cuda_version }}"]
         driver_kind: ["cuda"]
     steps:
-      - name: Check CUDA version
+      - name: Load CUDA config
+        id: load_config
         run: |
-          echo "Received CUDA version: ${{ needs.load_config.outputs.cuda_version }}"
-      - name: Build with CUDA version
-        run: |
-          CUDA_VERSION="${{ needs.load_config.outputs.cuda_version }}"
-          if [ -z "$CUDA_VERSION" ]; then
-            echo "Error: CUDA version is empty"
-            exit 1
-          else
-            echo "Building with CUDA version: $CUDA_VERSION"
-            # Your build command here
-          fi      
+          cuda_version=$(yq e '.cuda.version' driver_config.yml)
+          echo "CUDA_VERSION=$cuda_version"
+          echo "cuda_version=$cuda_version" >> $GITHUB_OUTPUT      
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
@@ -69,7 +37,7 @@ jobs:
       - uses: paulhatch/semantic-version@v5.0.0-alpha2
         with:
           bump_each_commit: false
-          version_format: "${{ matrix.driver_kind}}-${{ matrix.driver_version }}-sha-${GITHUB_SHA:0:6}"
+          version_format: "cuda-${{ steps.load_config.outputs.cuda_version }}-sha-${GITHUB_SHA:0:6}"
         id: semver
       - name: 'Check version'
         run: |
@@ -86,7 +54,7 @@ jobs:
           set -x
           echo "tag is: "
           echo ${{ steps.semver.outputs.version }}
-          docker buildx build --build-arg DRIVER_KIND=${{ matrix.driver_kind }} --build-arg DRIVER_VERSION=${{ matrix.driver_version }} --cache-from=type=local,src=/tmp/.buildx-cache --cache-to=type=local,dest=/tmp/.buildx-cache-new --output=type=docker -t ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-gpu:${{ steps.semver.outputs.version }} .
+          docker buildx build --build-arg DRIVER_KIND=${{ matrix.driver_kind }} --build-arg DRIVER_VERSION=${{ steps.load_config.outputs.cuda_version }} --cache-from=type=local,src=/tmp/.buildx-cache --cache-to=type=local,dest=/tmp/.buildx-cache-new --output=type=docker -t ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-gpu:${{ steps.semver.outputs.version }} .
           docker images
           az acr login -n ${{ secrets.AZURE_REGISTRY_SERVER }}
           docker push ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-gpu:${{ steps.semver.outputs.version }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        driver_version: ["550.90.07"]
+        driver_version: ["${{ needs.load_config.outputs.cuda_version }}"]
         driver_kind: ["cuda"]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,7 +8,26 @@ permissions:
   id-token: write
   contents: read
 
-jobs: 
+jobs:
+  load_config:
+    runs-on: ubuntu-latest
+    outputs:
+      cuda_version: ${{ steps.set_config.outputs.cuda_version }}
+      grid_version: ${{ steps.set_config.outputs.grid_version }}
+      grid_url: ${{ steps.set_config.outputs.grid_url }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod a+x /usr/local/bin/yq
+      - name: Load config
+        id: set_config
+        run: |
+          echo "cuda_version=$(yq e '.cuda.version' ../../driver_config.yml)" >> $GITHUB_OUTPUT
+          echo "grid_version=$(yq e '.grid.version' ../../driver_config.yml)" >> $GITHUB_OUTPUT
+          echo "grid_url=$(yq e '.grid.url' ../../driver_config.yml)" >> $GITHUB_OUTPUT
+ 
   cuda:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,10 +16,22 @@ jobs:
         driver_version: ["${{ needs.load_config.outputs.cuda_version }}"]
         driver_kind: ["cuda"]
     steps:
+      - name: Debug directory
+        run: |
+          pwd
+          ls -la
+          echo "Github workspace: $GITHUB_WORKSPACE"
       - name: Load CUDA config
         id: load_config
         run: |
-          cuda_version=$(yq e '.cuda.version' driver_config.yml)
+          if [ -f "$GITHUB_WORKSPACE/driver_config.yml" ]; then
+            cuda_version=$(yq e '.cuda.version' "$GITHUB_WORKSPACE/driver_config.yml")
+          elif [ -f "driver_config.yml" ]; then
+            cuda_version=$(yq e '.cuda.version' "driver_config.yml")
+          else
+            echo "driver_config.yml not found"
+            exit 1
+          fi
           echo "CUDA_VERSION=$cuda_version"
           echo "cuda_version=$cuda_version" >> $GITHUB_OUTPUT      
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,22 +19,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Debug directory
-        run: |
-          pwd
-          ls -la
-          echo "Github workspace: $GITHUB_WORKSPACE"
       - name: Load CUDA config
         id: load_config
         run: |
-          if [ -f "$GITHUB_WORKSPACE/driver_config.yml" ]; then
-            cuda_version=$(yq e '.cuda.version' "$GITHUB_WORKSPACE/driver_config.yml")
-          elif [ -f "driver_config.yml" ]; then
-            cuda_version=$(yq e '.cuda.version' "driver_config.yml")
-          else
-            echo "driver_config.yml not found"
-            exit 1
-          fi
+          cuda_version=$(yq e '.cuda.version' driver_config.yml)
           echo "CUDA_VERSION=$cuda_version"
           echo "cuda_version=$cuda_version" >> $GITHUB_OUTPUT      
       - name: Set up Docker Buildx

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,9 +24,15 @@ jobs:
       - name: Load config
         id: set_config
         run: |
-          echo "cuda_version=$(yq e '.cuda.version' driver_config.yml)" >> $GITHUB_OUTPUT
-          echo "grid_version=$(yq e '.grid.version' driver_config.yml)" >> $GITHUB_OUTPUT
-          echo "grid_url=$(yq e '.grid.url' ../../driver_config.yml)" >> $GITHUB_OUTPUT
+          CUDA_VERSION=$(yq e '.cuda.version' driver_config.yml)
+          GRID_VERSION=$(yq e '.grid.version' driver_config.yml)
+          GRID_URL=$(yq e '.grid.url' driver_config.yml)
+          echo "CUDA_VERSION=$CUDA_VERSION"
+          echo "GRID_VERSION=$GRID_VERSION"
+          echo "GRID_URL=$GRID_URL"
+          echo "::set-output name=cuda_version::$CUDA_VERSION"
+          echo "::set-output name=grid_version::$GRID_VERSION"
+          echo "::set-output name=grid_url::$GRID_URL"
  
   cuda:
     runs-on: ubuntu-latest
@@ -35,6 +41,19 @@ jobs:
         driver_version: ["${{ needs.load_config.outputs.cuda_version }}"]
         driver_kind: ["cuda"]
     steps:
+      - name: Check CUDA version
+        run: |
+          echo "Received CUDA version: ${{ needs.load_config.outputs.cuda_version }}"
+      - name: Build with CUDA version
+        run: |
+          CUDA_VERSION="${{ needs.load_config.outputs.cuda_version }}"
+          if [ -z "$CUDA_VERSION" ]; then
+            echo "Error: CUDA version is empty"
+            exit 1
+          else
+            echo "Building with CUDA version: $CUDA_VERSION"
+            # Your build command here
+          fi      
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -16,6 +16,9 @@ jobs:
         driver_version: ["${{ needs.load_config.outputs.cuda_version }}"]
         driver_kind: ["cuda"]
     steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Debug directory
         run: |
           pwd
@@ -34,9 +37,6 @@ jobs:
           fi
           echo "CUDA_VERSION=$cuda_version"
           echo "cuda_version=$cuda_version" >> $GITHUB_OUTPUT      
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Cache Docker layers

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -24,8 +24,8 @@ jobs:
       - name: Load config
         id: set_config
         run: |
-          echo "cuda_version=$(yq e '.cuda.version' ../../driver_config.yml)" >> $GITHUB_OUTPUT
-          echo "grid_version=$(yq e '.grid.version' ../../driver_config.yml)" >> $GITHUB_OUTPUT
+          echo "cuda_version=$(yq e '.cuda.version' driver_config.yml)" >> $GITHUB_OUTPUT
+          echo "grid_version=$(yq e '.grid.version' driver_config.yml)" >> $GITHUB_OUTPUT
           echo "grid_url=$(yq e '.grid.url' ../../driver_config.yml)" >> $GITHUB_OUTPUT
  
   cuda:

--- a/driver_config.yml
+++ b/driver_config.yml
@@ -1,0 +1,6 @@
+cuda:
+  version: "550.90.07"
+
+grid:
+  version: "535.161.08"
+  url: "https://download.microsoft.com/download/8/d/a/8da4fb8e-3a9b-4e6a-bc9a-72ff64d7a13c/NVIDIA-Linux-x86_64-535.161.08-grid-azure.run"

--- a/justfile
+++ b/justfile
@@ -2,7 +2,6 @@ grid_535_url    := "https://download.microsoft.com/download/8/d/a/8da4fb8e-3a9b-
 
 grid_535_driver := "535.161.08"
 
-cuda_550_driver := "550.90.07"
 registry := "docker.io/alexeldeib"
 
 default:

--- a/justfile
+++ b/justfile
@@ -7,12 +7,12 @@ registry := "docker.io/alexeldeib"
 
 default:
 
-pushallcuda: (pushcuda cuda_550_driver)
+pushallcuda: (pushcuda)
 
 pushallgrid: (pushgrid grid_535_driver)
 
-pushcuda VERSION: (buildcuda VERSION)
-	docker push {{ registry }}/aks-gpu:{{VERSION}}-cuda
+pushcuda: (buildcuda)
+	docker push {{ registry }}/aks-gpu:$(yq e '.cuda.version' driver_config.yml)-cuda
 
 pushgrid VERSION URL: (buildgrid VERSION URL)
 	docker push {{ registry }}/aks-gpu:{{VERSION}}-grid


### PR DESCRIPTION
This is to move drivers to 1 config file instead of being copy-pasted multiple times across 3 files. 
It will also aid in automation of the GPU driver updates.

This PR moves both CUDA and GRID drivers to a config file. The pipeline changes are for the CUDA driver here. GRID driver changes will be done in a separate PR. 