### PR TITLE
remove Nvidia docker version variable

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -1,6 +1,5 @@
 DRIVER_VERSION="${DRIVER_VERSION}"
 DRIVER_KIND="${DRIVER_KIND}"
-NVIDIA_DOCKER_VERSION="2.8.0-1"
 NVIDIA_CONTAINER_RUNTIME_VERSION="3.13.0"
 NVIDIA_CONTAINER_TOOLKIT_VER="1.16.0"
 NVIDIA_PACKAGES="libnvidia-container1 libnvidia-container-tools nvidia-container-toolkit-base nvidia-container-toolkit"


### PR DESCRIPTION
Removing it as it is not used, for any new aks-gpu container builds