### PR TITLE
fix typo in GRID version variable

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -91,7 +91,7 @@ jobs:
       - uses: paulhatch/semantic-version@v5.0.0-alpha2
         with:
           bump_each_commit: false
-          version_format: "${{ matrix.driver_kind}}-${{ steps.load_config.outputs.grid_versionn }}-sha-${GITHUB_SHA:0:6}"
+          version_format: "${{ matrix.driver_kind}}-${{ steps.load_config.outputs.grid_version }}-sha-${GITHUB_SHA:0:6}"
         id: semver
       - name: 'Check version'
         run: |


### PR DESCRIPTION
This resulted in the variable not being populated in the publish pipeline, and the pipeline subsequently failing.