### PR TITLE
Add renovate config and automated GPU driver updates for CUDA

### DIFF
--- a/driver_config.yml
+++ b/driver_config.yml
@@ -1,5 +1,5 @@
 cuda:
-  # renovate: datasource=custom.nvidia-driver depName=nvidia-cuda-driver
+  # renovate: datasource=custom.nvidia-driver depName=nvidia-cuda-driver versioning=loose
   version: "550.90.07"
 
 grid:

--- a/driver_config.yml
+++ b/driver_config.yml
@@ -1,4 +1,5 @@
 cuda:
+  # renovate: datasource=custom.nvidia-driver depName=nvidia-cuda-driver
   version: "550.90.07"
 
 grid:

--- a/renovate.json
+++ b/renovate.json
@@ -7,11 +7,8 @@
         "driver_config.yml"
       ],
       "matchStrings": [
-        "cuda:\\s*(?:#.*)?\\n\\s*version:\\s*\"(?<currentValue>[^\"]+)\""
-      ],
-      "depNameTemplate": "nvidia-cuda-driver",
-      "datasourceTemplate": "custom.nvidia-driver",
-      "versioningTemplate": "loose"
+        "#\\s*renovate:\\s*(datasource=(?<datasource>.*?) )?depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s*.*?version.*\\\"(?<currentValue>.*)\\\""
+      ]
     }
   ],
   "customDatasources": {

--- a/renovate.json
+++ b/renovate.json
@@ -19,14 +19,6 @@
     ]
   }
  },
-  "packageRules": [
-    {
-      "excludePackagePatterns": [".*"],
-      "managers": ["regex"],
-      "matchManagers": ["regex"],
-      "enabled": true
-    }
-  ],
   "logLevelRemap": [
     {
       "matchMessage": "/^Custom manager fetcher/",

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "driver_config.yml"
+      ],
+      "matchStrings": [
+        "cuda:\\s*(?:#.*)?\\n\\s*version:\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "depNameTemplate": "nvidia-cuda-driver",
+      "datasourceTemplate": "custom.nvidia-driver",
+      "versioningTemplate": "loose"
+    }
+  ],
+  "customDatasources": {
+  "nvidia-driver": {
+    "defaultRegistryUrlTemplate": "https://docs.nvidia.com/datacenter/tesla/drivers/releases.json",
+    "transformTemplates": [
+      "{ \"releases\": $map($reduce($map($keys($), function($k) { { \"key\": $k, \"value\": $lookup($, $k) } }), function($acc, $v) { $append($acc, $v.value.driver_info) }, []), function($info) { { \"version\": $info.release_version } }) }"
+    ]
+  }
+ },
+  "packageRules": [
+    {
+      "excludePackagePatterns": [".*"],
+      "managers": ["regex"],
+      "matchManagers": ["regex"],
+      "enabled": true
+    }
+  ],
+  "logLevelRemap": [
+    {
+      "matchMessage": "/^Custom manager fetcher/",
+      "newLogLevel": "debug"
+    },
+    {
+      "matchMessage": "/custom datasource/",
+      "newLogLevel": "debug"
+    }
+  ]
+}


### PR DESCRIPTION
This adds renovate config for automated updates via the renovate bot.

This configuration will auto-update CUDA drivers to the latest production branch via creating new PRs. It uses the Nvidia releases page as the source: https://docs.nvidia.com/datacenter/tesla/drivers/releases.json.