### PR TITLE
Update nvidia container toolkit to 1.16.2

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -1,6 +1,6 @@
 DRIVER_VERSION="${DRIVER_VERSION}"
 DRIVER_KIND="${DRIVER_KIND}"
 NVIDIA_CONTAINER_RUNTIME_VERSION="3.13.0"
-NVIDIA_CONTAINER_TOOLKIT_VER="1.16.0"
+NVIDIA_CONTAINER_TOOLKIT_VER="1.16.2"
 NVIDIA_PACKAGES="libnvidia-container1 libnvidia-container-tools nvidia-container-toolkit-base nvidia-container-toolkit"
 GPU_DEST="/usr/local/nvidia"


### PR DESCRIPTION
This is for the CVE fix for https://nvd.nist.gov/vuln/detail/CVE-2024-0132#VulnChangeHistorySection 