### PR TITLE
Removing unused Nvidia container runtime version variable

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -1,6 +1,5 @@
 DRIVER_VERSION="${DRIVER_VERSION}"
 DRIVER_KIND="${DRIVER_KIND}"
-NVIDIA_CONTAINER_RUNTIME_VERSION="3.13.0"
 NVIDIA_CONTAINER_TOOLKIT_VER="1.16.2"
 NVIDIA_PACKAGES="libnvidia-container1 libnvidia-container-tools nvidia-container-toolkit-base nvidia-container-toolkit"
 GPU_DEST="/usr/local/nvidia"


### PR DESCRIPTION
Removing this unused version - it's been deprecated and not used anymore. Cleaning this up for nvidia container toolkit automation later.