### PR TITLE
Configure auto-updates for nvidia-container-toolkit (via Renovate)

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -1,6 +1,5 @@
 DRIVER_VERSION="${DRIVER_VERSION}"
 DRIVER_KIND="${DRIVER_KIND}"
-NVIDIA_CONTAINER_RUNTIME_VERSION="3.13.0"
 NVIDIA_CONTAINER_TOOLKIT_VER="1.16.2"
 NVIDIA_PACKAGES="libnvidia-container1 libnvidia-container-tools nvidia-container-toolkit-base nvidia-container-toolkit"
 GPU_DEST="/usr/local/nvidia"

--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,16 @@
       "matchStrings": [
         "#\\s*renovate:\\s*(datasource=(?<datasource>.*?) )?depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s*.*?version.*\\\"(?<currentValue>.*)\\\""
       ]
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["config\\.sh"],
+      "matchStrings": [
+        "NVIDIA_CONTAINER_TOOLKIT_VER=\"(?<currentValue>.*?)\""
+      ],
+      "datasourceTemplate": "github-releases",
+      "depNameTemplate": "NVIDIA/nvidia-container-toolkit",
+      "versioningTemplate": "semver"
     }
   ],
   "customDatasources": {


### PR DESCRIPTION
This updates the nvidia-container-toolkit version, which is used to determine the version to download for these packages: `libnvidia-container1`, `libnvidia-container-tools`, `nvidia-container-toolkit-base`, and `nvidia-container-toolkit`