### PR TITLE
fix: check cache folder before removing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,9 @@ jobs:
           docker images
       - name: Move cache
         run: |
-          rm -r /tmp/.buildx-cache
+          if [ -d /tmp/.buildx-cache ]; then
+            rm -r /tmp/.buildx-cache
+          fi
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
   grid:
       runs-on: ubuntu-latest
@@ -101,5 +103,7 @@ jobs:
             docker images
         - name: Move cache
           run: |
-            rm -r /tmp/.buildx-cache
+            if [ -d /tmp/.buildx-cache ]; then
+              rm -r /tmp/.buildx-cache
+            fi
             mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -62,7 +62,9 @@ jobs:
           docker push ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-gpu-cuda:${{ steps.semver.outputs.version }}
       - name: Move cache
         run: |
-          rm -r /tmp/.buildx-cache
+          if [ -d /tmp/.buildx-cache ]; then
+            rm -r /tmp/.buildx-cache
+          fi
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
   grid:
     runs-on: ubuntu-latest
@@ -121,5 +123,7 @@ jobs:
           docker push ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-gpu-grid:${{ steps.semver.outputs.version }}
       - name: Move cache
         run: |
-          rm -r /tmp/.buildx-cache
+          if [ -d /tmp/.buildx-cache ]; then
+            rm -r /tmp/.buildx-cache
+          fi
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache


### PR DESCRIPTION
CI build steps fail when the cache folder does not exist.