### PR TITLE
Switch to 535.161.08 for GRID drivers

### DIFF
--- a/driver_config.yml
+++ b/driver_config.yml
@@ -3,5 +3,5 @@ cuda:
   version: "550.144.03"
 
 grid:
-  version: "550.144.03"
-  url: "https://download.microsoft.com/download/c/3/4/c3484f19-fe76-4495-a65d-a5222ead9517/NVIDIA-Linux-x86_64-550.144.03-grid-azure.run"
+  version: "535.161.08"
+  url: "https://download.microsoft.com/download/8/d/a/8da4fb8e-3a9b-4e6a-bc9a-72ff64d7a13c/NVIDIA-Linux-x86_64-535.161.08-grid-azure.run"


### PR DESCRIPTION
Reverting back to 535 drivers since 550 drivers don't install the nvidia-gridd systemd unit and have licensing issues.
The license status is set to Unlicensed, post provisioning. 

Till we get confirmation from Nvidia/HPC team, we will have to go back to the older version to limit impact. 