### PR TITLE
Remove GPU_DEST for nvidia installer to keep nvidia-gridd and nvidia-topology service files

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -64,16 +64,6 @@ popd
 # move nvidia libs to correct location from temporary overlayfs
 cp -a /tmp/overlay/lib64 ${GPU_DEST}/lib64
 
-# grid starts a daemon that prevents copying binaries
-if [ "${DRIVER_KIND}" == "grid" ]; then
-    systemctl stop nvidia-gridd || true
-fi
-
-# restart that daemon, lol
-if [ "${DRIVER_KIND}" == "grid" ]; then
-    systemctl restart nvidia-gridd || true
-fi
-
 # configure system to know about nvidia lib paths
 echo "${GPU_DEST}/lib64" > /etc/ld.so.conf.d/nvidia.conf
 ldconfig 

--- a/install.sh
+++ b/install.sh
@@ -58,7 +58,7 @@ fi
 
 # install nvidia drivers
 pushd /opt/gpu
-/opt/gpu/${RUNFILE}/nvidia-installer -s -k=$KERNEL_NAME --log-file-name=${LOG_FILE_NAME} -a --no-drm --dkms --utility-prefix="${GPU_DEST}" --opengl-prefix="${GPU_DEST}"
+/opt/gpu/${RUNFILE}/nvidia-installer -s -k=$KERNEL_NAME --log-file-name=${LOG_FILE_NAME} -a --no-drm --dkms --opengl-prefix="${GPU_DEST}"
 popd
 
 # move nvidia libs to correct location from temporary overlayfs
@@ -68,9 +68,6 @@ cp -a /tmp/overlay/lib64 ${GPU_DEST}/lib64
 if [ "${DRIVER_KIND}" == "grid" ]; then
     systemctl stop nvidia-gridd || true
 fi
-
-# move nvidia binaries to /usr/bin...because we like that?
-cp -rvT ${GPU_DEST}/bin /usr/bin || true
 
 # restart that daemon, lol
 if [ "${DRIVER_KIND}" == "grid" ]; then


### PR DESCRIPTION
This is to run the nvidia-gridd service and the nvidia-topology service. Nvidia recommends avoiding the use of the custom directory. 