### PR TITLE
Move nvidia systemd units after corresponding binaries have been moved

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -91,9 +91,13 @@ handle_nvidia_systemd_units() {
     # Reload systemd to pick up the moved unit files
     systemctl daemon-reload
 
+    # Enable and restart only the moved units
+    for unit_name in "${moved_units[@]}"; do
+        systemctl enable "$unit_name"
+        systemctl start "$unit_name"
+        echo "$unit_name enabled and started."
+    done
 }
-
-handle_nvidia_systemd_units
 
 # grid starts a daemon that prevents copying binaries
 if [ "${DRIVER_KIND}" == "grid" ]; then
@@ -107,6 +111,8 @@ cp -rvT ${GPU_DEST}/bin /usr/bin || true
 if [ "${DRIVER_KIND}" == "grid" ]; then
     systemctl restart nvidia-gridd || true
 fi
+
+handle_nvidia_systemd_units
 
 # configure system to know about nvidia lib paths
 echo "${GPU_DEST}/lib64" > /etc/ld.so.conf.d/nvidia.conf

--- a/install.sh
+++ b/install.sh
@@ -91,12 +91,6 @@ handle_nvidia_systemd_units() {
     # Reload systemd to pick up the moved unit files
     systemctl daemon-reload
 
-    # Enable and restart only the moved units
-    for unit_name in "${moved_units[@]}"; do
-        systemctl enable "$unit_name"
-        systemctl restart "$unit_name"
-        echo "$unit_name enabled and restarted."
-    done
 }
 
 handle_nvidia_systemd_units


### PR DESCRIPTION
CSE fails with the current AKS GPU container image from master, because it attempt to enable before the corresponding binaries are in the right path:

```
root@aks-nodepool1-99301939-vmss000000:/# cat /etc/systemd/system/nvidia-gridd.service
# NVIDIA Grid Daemon Init Script
#
# Copyright (c) 2015-2022 NVIDIA Corporation
#
# All rights reserved.  All information contained herein is proprietary and
# confidential to NVIDIA Corporation.  Any use, reproduction, or disclosure
# without the written permission of NVIDIA Corporation is prohibited.
#

[Unit]
Description=NVIDIA Grid Daemon
Wants=syslog.target network-online.target
After=systemd-resolved.service network-online.target nss-lookup.target

[Service]
Environment="LD_LIBRARY_PATH=/usr/lib/nvidia/gridd" "KRB5_CLIENT_KTNAME=/etc/krb5.keytab"
Type=forking
ExecStart=/usr/bin/nvidia-gridd
ExecStopPost=/bin/rm -rf /var/run/nvidia-gridd

[Install]
WantedBy=multi-user.target
```