### PR TITLE
Remove custom nvidia persistenced systemd unit

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -59,6 +59,7 @@ fi
 # install nvidia drivers
 pushd /opt/gpu
 /opt/gpu/${RUNFILE}/nvidia-installer -s -k=$KERNEL_NAME --log-file-name=${LOG_FILE_NAME} -a --no-drm --dkms
+nvidia-smi
 popd
 
 # move nvidia libs to correct location from temporary overlayfs
@@ -84,9 +85,6 @@ nvidia-modprobe -u -c0
 # reduces nvidia-smi invocation time 10x from 30 to 2 sec 
 # notable on large VM sizes with multiple GPUs
 # especially when nvidia-smi process is in CPU cgroup
-cp /opt/gpu/nvidia-persistenced.service /etc/systemd/system/nvidia-persistenced.service
-systemctl enable nvidia-persistenced.service
-systemctl restart nvidia-persistenced.service
 nvidia-smi
 
 # install fabricmanager for nvlink based systems


### PR DESCRIPTION
Removing it since nvidia-installer creates persistenced unit here:

```
root@aks-a10npskip-39370903-vmss000002:/# cat /lib/systemd/system/nvidia-persistenced.service
# NVIDIA Persistence Daemon Init Script
#
# Copyright (c) 2023 NVIDIA Corporation
#
# All rights reserved. All information contained herein is proprietary and
# confidential to NVIDIA Corporation. Any use, reproduction, or disclosure
# without the written permission of NVIDIA Corporation is prohibited.
#

[Unit]
Description=NVIDIA Persistence Daemon
Wants=syslog.target

[Service]
Type=forking
ExecStart=/usr/bin/nvidia-persistenced
ExecStopPost=/bin/rm -rf /var/run/nvidia-persistenced

[Install]
WantedBy=multi-user.target
```