### PR TITLE
Include nvidia-fabricmanager-start.sh script

### DIFF
--- a/fabricmanager.md
+++ b/fabricmanager.md
@@ -7,6 +7,7 @@ root@518f7df53862:/opt/gpu/fabricmanager-linux-x86_64-470.57.02# tree
 |-- LICENSE
 |-- bin
 |   |-- nv-fabricmanager
+|   |-- nvidia-fabricmanager-start.sh
 |   `-- nvswitch-audit
 |-- etc
 |   `-- fabricmanager.cfg

--- a/fm_run_package_installer.sh
+++ b/fm_run_package_installer.sh
@@ -29,6 +29,8 @@ cp -P ${ROOTDIR}/lib/libnvfm.so   /usr/lib/x86_64-linux-gnu
 
 cp ${ROOTDIR}/bin/nv-fabricmanager  /usr/bin
 cp ${ROOTDIR}/bin/nvswitch-audit  /usr/bin
+cp ${ROOTDIR}/bin/nvidia-fabricmanager-start.sh /usr/bin
+
 cp ${ROOTDIR}/systemd/nvidia-fabricmanager.service  /lib/systemd/system
 
 mkdir /usr/share/nvidia  > /dev/null 2>&1


### PR DESCRIPTION
- Include `nvidia-fabricmanager-start.sh` in `bin` directory
- Copy startup script to `/usr/bin` during package installation