### PR TITLE
Just use multiarch Docker image for CUDA drivers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,55 @@ jobs:
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+  cuda-arm64:
+    runs-on: ubuntu-24.04-arm  # see https://github.com/actions/partner-runner-images?tab=readme-ov-file#available-images
+    strategy:
+      matrix:
+        driver_kind: ["cuda"]
+        platform:
+          - linux/arm64
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Load CUDA config
+        id: load_config
+        run: |
+          cuda_version=$(yq e '.cuda.version' driver_config.yml)
+          echo "CUDA_VERSION=$cuda_version"
+          echo "cuda_version=$cuda_version" >> $GITHUB_OUTPUT
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Generate timestamp
+        id: timestamp
+        run: echo "timestamp=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
+      - uses: paulhatch/semantic-version@v5.0.0-alpha2
+        with:
+          bump_each_commit: false
+          version_format: "${{ steps.load_config.outputs.cuda_version }}-${{ steps.timestamp.outputs.timestamp }}"
+        id: semver
+      - name: 'Check version'
+        run: |
+          echo "version is ${{ steps.semver.outputs.version }}"
+          echo "version is ${{ steps.semver.outputs.version_tag }}"
+      - name: 'Build and Push'
+        run: |
+          set -x
+          echo "tag is: "
+          echo ${{ steps.semver.outputs.version }}
+          docker buildx build --build-arg DRIVER_KIND=${{ matrix.driver_kind }} --build-arg DRIVER_VERSION=${{ steps.load_config.outputs.cuda_version }} --cache-from=type=local,src=/tmp/.buildx-cache --cache-to=type=local,dest=/tmp/.buildx-cache-new --output=type=docker -t ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-gpu-cuda:${{ steps.semver.outputs.version }} .
+          docker images
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
   grid:
       runs-on: ubuntu-latest
       strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,56 +47,7 @@ jobs:
           set -x
           echo "tag is: "
           echo ${{ steps.semver.outputs.version }}
-          docker buildx build --build-arg DRIVER_KIND=${{ matrix.driver_kind }} --build-arg DRIVER_VERSION=${{ steps.load_config.outputs.cuda_version }} --cache-from=type=local,src=/tmp/.buildx-cache --cache-to=type=local,dest=/tmp/.buildx-cache-new --output=type=docker -t ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-gpu-cuda:${{ steps.semver.outputs.version }} .
-          docker images
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-  cuda-arm64:
-    runs-on: ubuntu-24.04-arm  # see https://github.com/actions/partner-runner-images?tab=readme-ov-file#available-images
-    strategy:
-      matrix:
-        driver_kind: ["cuda"]
-        platform:
-          - linux/arm64
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Load CUDA config
-        id: load_config
-        run: |
-          cuda_version=$(yq e '.cuda.version' driver_config.yml)
-          echo "CUDA_VERSION=$cuda_version"
-          echo "cuda_version=$cuda_version" >> $GITHUB_OUTPUT
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-      - name: Generate timestamp
-        id: timestamp
-        run: echo "timestamp=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
-      - uses: paulhatch/semantic-version@v5.0.0-alpha2
-        with:
-          bump_each_commit: false
-          version_format: "${{ steps.load_config.outputs.cuda_version }}-${{ steps.timestamp.outputs.timestamp }}"
-        id: semver
-      - name: 'Check version'
-        run: |
-          echo "version is ${{ steps.semver.outputs.version }}"
-          echo "version is ${{ steps.semver.outputs.version_tag }}"
-      - name: 'Build and Push'
-        run: |
-          set -x
-          echo "tag is: "
-          echo ${{ steps.semver.outputs.version }}
-          docker buildx build --build-arg DRIVER_KIND=${{ matrix.driver_kind }} --build-arg DRIVER_VERSION=${{ steps.load_config.outputs.cuda_version }} --cache-from=type=local,src=/tmp/.buildx-cache --cache-to=type=local,dest=/tmp/.buildx-cache-new --output=type=docker -t ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-gpu-cuda:${{ steps.semver.outputs.version }} .
+          docker buildx build --platform linux/arm64/v8,linux/amd64 --build-arg DRIVER_KIND=${{ matrix.driver_kind }} --build-arg DRIVER_VERSION=${{ steps.load_config.outputs.cuda_version }} --cache-from=type=local,src=/tmp/.buildx-cache --cache-to=type=local,dest=/tmp/.buildx-cache-new --output=type=docker -t ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-gpu-cuda:${{ steps.semver.outputs.version }} .
           docker images
       - name: Move cache
         run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -64,6 +64,63 @@ jobs:
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+  cuda-arm64:
+    runs-on: ubuntu-24.04-arm  # see https://github.com/actions/partner-runner-images?tab=readme-ov-file#available-images
+    strategy:
+      matrix:
+        driver_kind: ["cuda"]
+        platform:
+          - linux/arm64
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Load CUDA config
+        id: load_config
+        run: |
+          cuda_version=$(yq e '.cuda.version' driver_config.yml)
+          echo "CUDA_VERSION=$cuda_version"
+          echo "cuda_version=$cuda_version" >> $GITHUB_OUTPUT      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+      - name: Generate timestamp
+        id: timestamp
+        run: echo "timestamp=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
+      - uses: paulhatch/semantic-version@v5.0.0-alpha2
+        with:
+          bump_each_commit: false
+          version_format: "${{ steps.load_config.outputs.cuda_version }}-${{ steps.timestamp.outputs.timestamp }}"
+        id: semver
+      - name: 'Check version'
+        run: |
+          echo "version is ${{ steps.semver.outputs.version }}"
+          echo "version is ${{ steps.semver.outputs.version_tag }}"
+      - name: 'Azure CLI login'
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: 'Build and Push'
+        run: |
+          set -x
+          echo "tag is: "
+          echo ${{ steps.semver.outputs.version }}
+          docker buildx build --build-arg DRIVER_KIND=${{ matrix.driver_kind }} --build-arg DRIVER_VERSION=${{ steps.load_config.outputs.cuda_version }} --build-arg ARCH=arm64 --cache-from=type=local,src=/tmp/.buildx-cache --cache-to=type=local,dest=/tmp/.buildx-cache-new --output=type=docker -t ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-gpu-cuda-arm64:${{ steps.semver.outputs.version }} .
+          docker images
+          az acr login -n ${{ secrets.AZURE_REGISTRY_SERVER }}
+          docker push ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-gpu-cuda-arm64:${{ steps.semver.outputs.version }}
+      - name: Move cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
   grid:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -56,7 +56,7 @@ jobs:
           set -x
           echo "tag is: "
           echo ${{ steps.semver.outputs.version }}
-          docker buildx build --build-arg DRIVER_KIND=${{ matrix.driver_kind }} --build-arg DRIVER_VERSION=${{ steps.load_config.outputs.cuda_version }} --cache-from=type=local,src=/tmp/.buildx-cache --cache-to=type=local,dest=/tmp/.buildx-cache-new --output=type=docker -t ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-gpu-cuda:${{ steps.semver.outputs.version }} .
+          docker buildx build --build-arg DRIVER_KIND=${{ matrix.driver_kind }} --build-arg DRIVER_VERSION=${{ steps.load_config.outputs.cuda_version }} --build-arg ARCH=x86_64 --cache-from=type=local,src=/tmp/.buildx-cache --cache-to=type=local,dest=/tmp/.buildx-cache-new --output=type=docker -t ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-gpu-cuda:${{ steps.semver.outputs.version }} .
           docker images
           az acr login -n ${{ secrets.AZURE_REGISTRY_SERVER }}
           docker push ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-gpu-cuda:${{ steps.semver.outputs.version }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -56,7 +56,7 @@ jobs:
           set -x
           echo "tag is: "
           echo ${{ steps.semver.outputs.version }}
-          docker buildx build --build-arg DRIVER_KIND=${{ matrix.driver_kind }} --build-arg DRIVER_VERSION=${{ steps.load_config.outputs.cuda_version }} --build-arg ARCH=x86_64 --cache-from=type=local,src=/tmp/.buildx-cache --cache-to=type=local,dest=/tmp/.buildx-cache-new --output=type=docker -t ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-gpu-cuda:${{ steps.semver.outputs.version }} .
+          docker buildx build --build-arg DRIVER_KIND=${{ matrix.driver_kind }} --build-arg DRIVER_VERSION=${{ steps.load_config.outputs.cuda_version }} --cache-from=type=local,src=/tmp/.buildx-cache --cache-to=type=local,dest=/tmp/.buildx-cache-new --output=type=docker -t ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-gpu-cuda:${{ steps.semver.outputs.version }} .
           docker images
           az acr login -n ${{ secrets.AZURE_REGISTRY_SERVER }}
           docker push ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-gpu-cuda:${{ steps.semver.outputs.version }}
@@ -113,7 +113,7 @@ jobs:
           set -x
           echo "tag is: "
           echo ${{ steps.semver.outputs.version }}
-          docker buildx build --build-arg DRIVER_KIND=${{ matrix.driver_kind }} --build-arg DRIVER_VERSION=${{ steps.load_config.outputs.cuda_version }} --build-arg ARCH=arm64 --cache-from=type=local,src=/tmp/.buildx-cache --cache-to=type=local,dest=/tmp/.buildx-cache-new --output=type=docker -t ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-gpu-cuda-arm64:${{ steps.semver.outputs.version }} .
+          docker buildx build --build-arg DRIVER_KIND=${{ matrix.driver_kind }} --build-arg DRIVER_VERSION=${{ steps.load_config.outputs.cuda_version }} --cache-from=type=local,src=/tmp/.buildx-cache --cache-to=type=local,dest=/tmp/.buildx-cache-new --output=type=docker -t ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-gpu-cuda-arm64:${{ steps.semver.outputs.version }} .
           docker images
           az acr login -n ${{ secrets.AZURE_REGISTRY_SERVER }}
           docker push ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-gpu-cuda-arm64:${{ steps.semver.outputs.version }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -56,67 +56,10 @@ jobs:
           set -x
           echo "tag is: "
           echo ${{ steps.semver.outputs.version }}
-          docker buildx build --build-arg DRIVER_KIND=${{ matrix.driver_kind }} --build-arg DRIVER_VERSION=${{ steps.load_config.outputs.cuda_version }} --cache-from=type=local,src=/tmp/.buildx-cache --cache-to=type=local,dest=/tmp/.buildx-cache-new --output=type=docker -t ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-gpu-cuda:${{ steps.semver.outputs.version }} .
+          docker buildx build --platform linux/arm64/v8,linux/amd64 --build-arg DRIVER_KIND=${{ matrix.driver_kind }} --build-arg DRIVER_VERSION=${{ steps.load_config.outputs.cuda_version }} --cache-from=type=local,src=/tmp/.buildx-cache --cache-to=type=local,dest=/tmp/.buildx-cache-new --output=type=docker -t ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-gpu-cuda:${{ steps.semver.outputs.version }} .
           docker images
           az acr login -n ${{ secrets.AZURE_REGISTRY_SERVER }}
           docker push ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-gpu-cuda:${{ steps.semver.outputs.version }}
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-  cuda-arm64:
-    runs-on: ubuntu-24.04-arm  # see https://github.com/actions/partner-runner-images?tab=readme-ov-file#available-images
-    strategy:
-      matrix:
-        driver_kind: ["cuda"]
-        platform:
-          - linux/arm64
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Load CUDA config
-        id: load_config
-        run: |
-          cuda_version=$(yq e '.cuda.version' driver_config.yml)
-          echo "CUDA_VERSION=$cuda_version"
-          echo "cuda_version=$cuda_version" >> $GITHUB_OUTPUT      
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-      - name: Generate timestamp
-        id: timestamp
-        run: echo "timestamp=$(date +'%Y%m%d%H%M%S')" >> $GITHUB_OUTPUT
-      - uses: paulhatch/semantic-version@v5.0.0-alpha2
-        with:
-          bump_each_commit: false
-          version_format: "${{ steps.load_config.outputs.cuda_version }}-${{ steps.timestamp.outputs.timestamp }}"
-        id: semver
-      - name: 'Check version'
-        run: |
-          echo "version is ${{ steps.semver.outputs.version }}"
-          echo "version is ${{ steps.semver.outputs.version_tag }}"
-      - name: 'Azure CLI login'
-        uses: azure/login@v2
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      - name: 'Build and Push'
-        run: |
-          set -x
-          echo "tag is: "
-          echo ${{ steps.semver.outputs.version }}
-          docker buildx build --build-arg DRIVER_KIND=${{ matrix.driver_kind }} --build-arg DRIVER_VERSION=${{ steps.load_config.outputs.cuda_version }} --cache-from=type=local,src=/tmp/.buildx-cache --cache-to=type=local,dest=/tmp/.buildx-cache-new --output=type=docker -t ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-gpu-cuda-arm64:${{ steps.semver.outputs.version }} .
-          docker images
-          az acr login -n ${{ secrets.AZURE_REGISTRY_SERVER }}
-          docker push ${{ secrets.AZURE_REGISTRY_SERVER }}/public/aks/aks-gpu-cuda-arm64:${{ steps.semver.outputs.version }}
       - name: Move cache
         run: |
           rm -rf /tmp/.buildx-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt update && apt install -y curl xz-utils gnupg2 ca-certificates gettext-ba
 ARG DRIVER_VERSION
 ARG DRIVER_URL
 ARG DRIVER_KIND="cuda"
+ARG TARGETARCH
 
 WORKDIR /opt/gpu
 COPY 10-nvidia-runtime.toml 10-nvidia-runtime.toml 

--- a/download.sh
+++ b/download.sh
@@ -7,11 +7,17 @@ source /opt/gpu/config.sh
 workdir="$(mktemp -d)"
 pushd "$workdir" || exit
 
+NVIDIA_ARCH=$ARCH
+if [[ "${ARCH}" == "arm64" ]]; then
+    # NVIDIA uses the name "SBSA" for ARM64 platforms. See https://en.wikipedia.org/wiki/Server_Base_System_Architecture
+    NVIDIA_ARCH="sbsa"
+fi
+
 if [[ "${DRIVER_KIND}" == "cuda" ]]; then
-    RUNFILE="NVIDIA-Linux-x86_64-${DRIVER_VERSION}"
+    RUNFILE="NVIDIA-Linux-${NVIDIA_ARCH}-${DRIVER_VERSION}"
     curl -fsSLO https://us.download.nvidia.com/tesla/${DRIVER_VERSION}/${RUNFILE}.run 
 elif [[ "${DRIVER_KIND}" == "grid" ]]; then
-    RUNFILE="NVIDIA-Linux-x86_64-${DRIVER_VERSION}-grid-azure"
+    RUNFILE="NVIDIA-Linux-${NVIDIA_ARCH}-${DRIVER_VERSION}-grid-azure"
     curl -fsSLO "${DRIVER_URL}"
 else
     echo "Invalid driver kind: ${DRIVER_KIND}"
@@ -26,12 +32,11 @@ sh /opt/gpu/${RUNFILE}.run -x
 rm /opt/gpu/${RUNFILE}.run
 popd
 
-
 install_fabric_manager () {
-    curl -fsSLO https://developer.download.nvidia.com/compute/nvidia-driver/redist/fabricmanager/linux-x86_64/fabricmanager-linux-x86_64-${DRIVER_VERSION}-archive.tar.xz
-    tar -xvf fabricmanager-linux-x86_64-${DRIVER_VERSION}-archive.tar.xz
-    mv fabricmanager-linux-x86_64-${DRIVER_VERSION}-archive /opt/gpu/fabricmanager-linux-x86_64-${DRIVER_VERSION}
-    mv /opt/gpu/fm_run_package_installer.sh /opt/gpu/fabricmanager-linux-x86_64-${DRIVER_VERSION}/sbin/fm_run_package_installer.sh
+    curl -fsSLO https://developer.download.nvidia.com/compute/nvidia-driver/redist/fabricmanager/linux-${NVIDIA_ARCH}/fabricmanager-linux-${NVIDIA_ARCH}-${DRIVER_VERSION}-archive.tar.xz
+    tar -xvf fabricmanager-linux-${NVIDIA_ARCH}-${DRIVER_VERSION}-archive.tar.xz
+    mv fabricmanager-linux-${NVIDIA_ARCH}-${DRIVER_VERSION}-archive /opt/gpu/fabricmanager-linux-${NVIDIA_ARCH}-${DRIVER_VERSION}
+    mv /opt/gpu/fm_run_package_installer.sh /opt/gpu/fabricmanager-linux-${NVIDIA_ARCH}-${DRIVER_VERSION}/sbin/fm_run_package_installer.sh
 }
 
 if [[ "${DRIVER_KIND}" == "cuda" ]]; then

--- a/download.sh
+++ b/download.sh
@@ -7,8 +7,8 @@ source /opt/gpu/config.sh
 workdir="$(mktemp -d)"
 pushd "$workdir" || exit
 
-NVIDIA_ARCH=$ARCH
-if [[ "${ARCH}" == "arm64" ]]; then
+NVIDIA_ARCH=$TARGETARCH
+if [[ "${TARGETARCH}" == "arm64" ]]; then
     # NVIDIA uses the name "SBSA" for ARM64 platforms. See https://en.wikipedia.org/wiki/Server_Base_System_Architecture
     NVIDIA_ARCH="sbsa"
 fi

--- a/download.sh
+++ b/download.sh
@@ -8,9 +8,11 @@ workdir="$(mktemp -d)"
 pushd "$workdir" || exit
 
 NVIDIA_ARCH=$TARGETARCH
-if [[ "${TARGETARCH}" == "arm64" ]]; then
+if [ $TARGETARCH = "arm64" ]; then
     # NVIDIA uses the name "SBSA" for ARM64 platforms. See https://en.wikipedia.org/wiki/Server_Base_System_Architecture
     NVIDIA_ARCH="sbsa"
+elif [ $TARGETARCH = "amd64" ]; then
+    NVIDIA_ARCH="x86_64"
 fi
 
 if [[ "${DRIVER_KIND}" == "cuda" ]]; then

--- a/download.sh
+++ b/download.sh
@@ -42,10 +42,10 @@ rm /opt/gpu/${RUNFILE}.run
 popd
 
 install_fabric_manager () {
-    curl -fsSLO https://developer.download.nvidia.com/compute/nvidia-driver/redist/fabricmanager/linux-${NVIDIA_ARCH}/fabricmanager-linux-${NVIDIA_ARCH}-${DRIVER_VERSION}-archive.tar.xz
-    tar -xvf fabricmanager-linux-${NVIDIA_ARCH}-${DRIVER_VERSION}-archive.tar.xz
-    mv fabricmanager-linux-${NVIDIA_ARCH}-${DRIVER_VERSION}-archive /opt/gpu/fabricmanager-linux-${NVIDIA_ARCH}-${DRIVER_VERSION}
-    mv /opt/gpu/fm_run_package_installer.sh /opt/gpu/fabricmanager-linux-${NVIDIA_ARCH}-${DRIVER_VERSION}/sbin/fm_run_package_installer.sh
+    curl -fsSLO https://developer.download.nvidia.com/compute/nvidia-driver/redist/fabricmanager/linux-${NVIDIA_FM_ARCH}/fabricmanager-linux-${NVIDIA_FM_ARCH}-${DRIVER_VERSION}-archive.tar.xz
+    tar -xvf fabricmanager-linux-${NVIDIA_FM_ARCH}-${DRIVER_VERSION}-archive.tar.xz
+    mv fabricmanager-linux-${NVIDIA_FM_ARCH}-${DRIVER_VERSION}-archive /opt/gpu/fabricmanager-linux-${NVIDIA_FM_ARCH}-${DRIVER_VERSION}
+    mv /opt/gpu/fm_run_package_installer.sh /opt/gpu/fabricmanager-linux-${NVIDIA_FM_ARCH}-${DRIVER_VERSION}/sbin/fm_run_package_installer.sh
 }
 
 if [[ "${DRIVER_KIND}" == "cuda" ]]; then

--- a/download.sh
+++ b/download.sh
@@ -7,19 +7,26 @@ source /opt/gpu/config.sh
 workdir="$(mktemp -d)"
 pushd "$workdir" || exit
 
-NVIDIA_ARCH=$TARGETARCH
+NVIDIA_DRIVER_ARCH=$TARGETARCH
 if [ $TARGETARCH = "arm64" ]; then
-    # NVIDIA uses the name "SBSA" for ARM64 platforms. See https://en.wikipedia.org/wiki/Server_Base_System_Architecture
-    NVIDIA_ARCH="sbsa"
+    NVIDIA_DRIVER_ARCH="aarch64"
 elif [ $TARGETARCH = "amd64" ]; then
-    NVIDIA_ARCH="x86_64"
+    NVIDIA_DRIVER_ARCH="x86_64"
+fi
+
+NVIDIA_FM_ARCH=$TARGETARCH
+if [ $TARGETARCH = "arm64" ]; then
+    # NVIDIA uses the name "SBSA" for ARM64 platforms for the fabric manager. See https://en.wikipedia.org/wiki/Server_Base_System_Architecture
+    NVIDIA_FM_ARCH="sbsa"
+elif [ $TARGETARCH = "amd64" ]; then
+    NVIDIA_FM_ARCH="x86_64"
 fi
 
 if [[ "${DRIVER_KIND}" == "cuda" ]]; then
-    RUNFILE="NVIDIA-Linux-${NVIDIA_ARCH}-${DRIVER_VERSION}"
+    RUNFILE="NVIDIA-Linux-${NVIDIA_DRIVER_ARCH}-${DRIVER_VERSION}"
     curl -fsSLO https://us.download.nvidia.com/tesla/${DRIVER_VERSION}/${RUNFILE}.run 
 elif [[ "${DRIVER_KIND}" == "grid" ]]; then
-    RUNFILE="NVIDIA-Linux-${NVIDIA_ARCH}-${DRIVER_VERSION}-grid-azure"
+    RUNFILE="NVIDIA-Linux-${NVIDIA_DRIVER_ARCH}-${DRIVER_VERSION}-grid-azure"
     curl -fsSLO "${DRIVER_URL}"
 else
     echo "Invalid driver kind: ${DRIVER_KIND}"

--- a/driver_config.yml
+++ b/driver_config.yml
@@ -4,4 +4,5 @@ cuda:
 
 grid:
   version: "550.144.06"
+  # We do not support GRID drivers on ARM64 architecture.
   url: "https://download.microsoft.com/download/c5319e92-672e-4067-8d85-ab66a7a64db3/NVIDIA-Linux-x86_64-550.144.06-grid-azure.run"

--- a/fm_run_package_installer.sh
+++ b/fm_run_package_installer.sh
@@ -24,8 +24,8 @@ STATUS=`systemctl is-active nvidia-fabricmanager`
 
 # copy all the files
 echo "Copying files to desired location"
-cp ${ROOTDIR}/lib/libnvfm.so.1 /usr/lib/x86_64-linux-gnu
-cp -P ${ROOTDIR}/lib/libnvfm.so   /usr/lib/x86_64-linux-gnu
+cp ${ROOTDIR}/lib/libnvfm.so.1 /usr/lib/$(uname -m)-linux-gnu
+cp -P ${ROOTDIR}/lib/libnvfm.so   /usr/lib/$(uname -m)-linux-gnu
 
 cp ${ROOTDIR}/bin/nv-fabricmanager  /usr/bin
 cp ${ROOTDIR}/bin/nvswitch-audit  /usr/bin

--- a/install.sh
+++ b/install.sh
@@ -91,7 +91,12 @@ nvidia-smi
 
 # install fabricmanager for nvlink based systems
 if [[ "${DRIVER_KIND}" == "cuda" ]]; then
-    bash /opt/gpu/fabricmanager-linux-$(uname -m)-${DRIVER_VERSION}/sbin/fm_run_package_installer.sh
+    NVIDIA_FM_ARCH=$(uname -m)
+    if [ $NVIDIA_FM_ARCH = "arm64" ]; then
+        # NVIDIA uses the name "SBSA" for ARM64 platforms for the fabric manager. See https://en.wikipedia.org/wiki/Server_Base_System_Architecture
+        NVIDIA_FM_ARCH="sbsa"
+    fi
+    bash /opt/gpu/fabricmanager-linux-${NVIDIA_FM_ARCH}-${DRIVER_VERSION}/sbin/fm_run_package_installer.sh
 fi
 
 mkdir -p /etc/containerd/config.d

--- a/install.sh
+++ b/install.sh
@@ -51,7 +51,11 @@ mount -t overlay overlay -o lowerdir=/usr/lib/$(uname -m)-linux-gnu,upperdir=/tm
 if [[ "${DRIVER_KIND}" == "cuda" ]]; then
     RUNFILE="NVIDIA-Linux-$(uname -m)-${DRIVER_VERSION}"
 elif [[ "${DRIVER_KIND}" == "grid" ]]; then
-    RUNFILE="NVIDIA-Linux-$(uname -m)-${DRIVER_VERSION}-grid-azure"
+    if [[ $(uname -m) != "x86_64" ]]; then
+        echo "GRID driver is only supported on x86_64 architecture"
+        exit 1
+    fi
+    RUNFILE="NVIDIA-Linux-x86_64-${DRIVER_VERSION}-grid-azure"
 else
     echo "Invalid driver kind: ${DRIVER_KIND}"
     exit 1


### PR DESCRIPTION
It will be simpler to build everything once using the `--platform` flag, then just get whatever arch we land on.