### PR TITLE
chore: update NVIDIA GRID driver to v18.6 (570.211.01)

### DIFF
--- a/driver_config.yml
+++ b/driver_config.yml
@@ -3,6 +3,6 @@ cuda:
   version: "595.71.05"
 
 grid:
-  version: "550.144.06"
+  version: "570.211.01"
   # We do not support GRID drivers on ARM64 architecture.
-  url: "https://download.microsoft.com/download/c5319e92-672e-4067-8d85-ab66a7a64db3/NVIDIA-Linux-x86_64-550.144.06-grid-azure.run"
+  url: "https://download.microsoft.com/download/2a04ca6a-9eec-40d9-9564-9cdea1ab795f/NVIDIA-Linux-x86_64-570.211.01-grid-azure.run"


### PR DESCRIPTION
Bumps the GRID driver from **550.144.06** (vGPU 17.55) to **570.211.01** (vGPU 18.6).

### Source

Version + URL pulled from the Azure HPC NVIDIA driver manifest:
[Azure/azhpc-extensions `NvidiaGPU/resources.json`](https://github.com/Azure/azhpc-extensions/blob/master/NvidiaGPU/resources.json) — the v18.6 Linux GRID entry:

```json
{
  "Num": "570.211.01",
  "DirLink": "https://download.microsoft.com/download/2a04ca6a-9eec-40d9-9564-9cdea1ab795f/NVIDIA-Linux-x86_64-570.211.01-grid-azure.run",
  "vGPUVersion": "18.6",
  "SupportedOSVersions": "Ubuntu 20.04 LTS, 22.04 LTS, 24.04 LTS, Red Hat Enterprise Linux 8.6, 8.8, 8.9"
}
```

URL verified `HTTP 200`.

### Auto-updater note

`auto_update.py` reads `Nvidia-GPU-Linux-Resources.json` which the HPC team stopped updating at v17.55 — so the daily auto-PR job won't surface v18.x bumps without changes. Follow-up PR will update `auto_update.py` to read from `resources.json` and filter by `vGPUVersion` major == `18`.