### PR TITLE
refactor(auto-updater): track latest patch within current GRID driver major

### DIFF
--- a/auto_update.py
+++ b/auto_update.py
@@ -1,37 +1,50 @@
 import os
+import re
 import requests
 from ruamel.yaml import YAML
 
-# Source of truth for Azure-mirrored NVIDIA GRID drivers. The HPC team
-# publishes the canonical driver manifest at this path; resources.json
-# contains all currently supported vGPU major versions (we previously read
-# Nvidia-GPU-Linux-Resources.json, but that file is no longer updated past
-# vGPU 17.55).
+# Source of truth for Azure-mirrored NVIDIA GRID drivers. resources.json
+# contains all currently-supported NVIDIA driver branches (we previously
+# read Nvidia-GPU-Linux-Resources.json, but that file is no longer updated
+# past 550.144.06 / vGPU 17.55).
 RESOURCES_JSON_URL = (
     "https://raw.githubusercontent.com/Azure/azhpc-extensions/"
     "refs/heads/master/NvidiaGPU/resources.json"
 )
 
-# Active vGPU major version. Bump this when migrating to the next major
-# (e.g. "18" -> "19") and the auto-updater will start tracking the latest
-# minor of that major. The auto-updater intentionally does NOT cross major
-# versions on its own, since major version bumps require validation.
-TARGET_VGPU_MAJOR = "18"
+# Driver versions look like "570.211.01" — major.minor.patch. The MAJOR
+# component corresponds to NVIDIA's driver branch (R570, R580, …) and is
+# the ABI-stable boundary: within one major, NVIDIA only ships
+# bug-fix / patch releases. Crossing a major (e.g. 570 -> 580) can
+# introduce kernel-module ABI changes, install-script differences, and
+# vGPU licensing changes, so it requires deliberate validation.
+DRIVER_VERSION_PATTERN = re.compile(r"^\d+(?:\.\d+){1,2}$")
 
 
-def _vgpu_sort_key(vgpu_version):
-    """Convert "18.6" / "18.10" into a tuple for ordering: (18, 6) / (18, 10)."""
-    return tuple(int(p) if p.isdigit() else 0 for p in vgpu_version.split("."))
+def _driver_sort_key(version_str):
+    """Convert "570.211.01" -> (570, 211, 1) so version comparisons are numeric."""
+    return tuple(int(p) for p in version_str.split(".") if p.isdigit())
 
 
-def get_latest_grid_driver():
-    """Return (driver_version, download_url) for the latest vGPU TARGET_VGPU_MAJOR.x
-    Linux GRID driver.
+def _current_driver_major(config):
+    """Return the driver major (e.g. '570') of the currently-pinned grid version."""
+    current = str(config.get("grid", {}).get("version", "")).strip()
+    if not DRIVER_VERSION_PATTERN.match(current):
+        raise RuntimeError(
+            f"Cannot determine driver major from grid.version={current!r} "
+            f"in driver_config.yml (expected like '570.211.01')."
+        )
+    return current.split(".")[0]
 
-    Walks OS.Linux.Version[*].Driver[*] in resources.json, collects all entries
-    whose vGPUVersion has major == TARGET_VGPU_MAJOR, and picks the one with the
-    highest minor. Falls back from DirLink to FwLink so we still get a usable URL
-    when the manifest puts the download in FwLink.
+
+def get_latest_grid_driver_for_major(target_major):
+    """Return (driver_version, download_url) for the highest version in
+    resources.json whose driver major matches target_major.
+
+    Walks OS.Linux.Version[*].Driver[*] for Type='GRID' blocks and keeps any
+    entry whose Num starts with f"{target_major}.". Falls back from DirLink
+    to FwLink so we still get a usable URL when the manifest puts the
+    download in FwLink (the v18.5 entry is one such example).
     """
     response = requests.get(RESOURCES_JSON_URL, timeout=30)
     response.raise_for_status()
@@ -43,34 +56,31 @@ def get_latest_grid_driver():
     if linux_block is None:
         raise RuntimeError("No 'Linux' OS block in NvidiaGPU/resources.json")
 
-    prefix = f"{TARGET_VGPU_MAJOR}."
+    prefix = f"{target_major}."
     candidates = {}
     for distro in linux_block.get("Version", []):
         for drv_block in distro.get("Driver", []):
             if drv_block.get("Type") != "GRID":
                 continue
             for v in drv_block.get("Version", []):
-                vgpu = str(v.get("vGPUVersion", "")).strip()
-                if not vgpu.startswith(prefix):
+                num = str(v.get("Num", "")).strip()
+                if not num.startswith(prefix):
                     continue
-                driver_num = v.get("Num")
                 url = v.get("DirLink") or v.get("FwLink")
-                if not driver_num or not url:
+                if not url:
                     continue
                 # Same driver may appear in multiple distro blocks; first wins.
-                candidates.setdefault(driver_num, {"vgpu": vgpu, "url": url})
+                candidates.setdefault(num, url)
 
     if not candidates:
         raise RuntimeError(
-            f"No vGPU {TARGET_VGPU_MAJOR}.x Linux GRID driver entries found "
-            f"in {RESOURCES_JSON_URL}"
+            f"No GRID driver {target_major}.x entries found in "
+            f"{RESOURCES_JSON_URL}. If NVIDIA has ended patches for this "
+            f"branch, bump driver_config.yml to the next major manually."
         )
 
-    best_num = max(
-        candidates,
-        key=lambda n: _vgpu_sort_key(candidates[n]["vgpu"]),
-    )
-    return best_num, candidates[best_num]["url"]
+    best = max(candidates, key=_driver_sort_key)
+    return best, candidates[best]
 
 
 def update_driver_config():
@@ -84,7 +94,8 @@ def update_driver_config():
     with open("driver_config.yml", "r") as f:
         config = yaml.load(f)
 
-    latest_version, latest_url = get_latest_grid_driver()
+    target_major = _current_driver_major(config)
+    latest_version, latest_url = get_latest_grid_driver_for_major(target_major)
 
     config['grid']['version'] = latest_version
     config['grid']['url'] = latest_url

--- a/auto_update.py
+++ b/auto_update.py
@@ -2,26 +2,77 @@ import os
 import requests
 from ruamel.yaml import YAML
 
-def get_latest_grid_driver():
-    # URL of the JSON file containing driver information
-    url = "https://raw.githubusercontent.com/Azure/azhpc-extensions/refs/heads/master/NvidiaGPU/Nvidia-GPU-Linux-Resources.json"
-    response = requests.get(url)
-    response.raise_for_status()  
-    data = response.json()
-    
-    # Extract the latest GRID driver information
-    grid_versions = data['Latest']['Category']
-    grid_info = next((item for item in grid_versions if item["Name"] == "GRID"), None)
-    
-    if grid_info:
-        latest_version_info = grid_info['Versions'][0]
-        latest_version = latest_version_info['DriverVersion']
-        latest_url = latest_version_info['Driver'][0]['DirLink']
-        return latest_version, latest_url
-    
-    raise Exception("Could not find latest GRID driver version")
+# Source of truth for Azure-mirrored NVIDIA GRID drivers. The HPC team
+# publishes the canonical driver manifest at this path; resources.json
+# contains all currently supported vGPU major versions (we previously read
+# Nvidia-GPU-Linux-Resources.json, but that file is no longer updated past
+# vGPU 17.55).
+RESOURCES_JSON_URL = (
+    "https://raw.githubusercontent.com/Azure/azhpc-extensions/"
+    "refs/heads/master/NvidiaGPU/resources.json"
+)
 
-# Add this at the end of your update_driver_config function
+# Active vGPU major version. Bump this when migrating to the next major
+# (e.g. "18" -> "19") and the auto-updater will start tracking the latest
+# minor of that major. The auto-updater intentionally does NOT cross major
+# versions on its own, since major version bumps require validation.
+TARGET_VGPU_MAJOR = "18"
+
+
+def _vgpu_sort_key(vgpu_version):
+    """Convert "18.6" / "18.10" into a tuple for ordering: (18, 6) / (18, 10)."""
+    return tuple(int(p) if p.isdigit() else 0 for p in vgpu_version.split("."))
+
+
+def get_latest_grid_driver():
+    """Return (driver_version, download_url) for the latest vGPU TARGET_VGPU_MAJOR.x
+    Linux GRID driver.
+
+    Walks OS.Linux.Version[*].Driver[*] in resources.json, collects all entries
+    whose vGPUVersion has major == TARGET_VGPU_MAJOR, and picks the one with the
+    highest minor. Falls back from DirLink to FwLink so we still get a usable URL
+    when the manifest puts the download in FwLink.
+    """
+    response = requests.get(RESOURCES_JSON_URL, timeout=30)
+    response.raise_for_status()
+    data = response.json()
+
+    linux_block = next(
+        (o for o in data.get("OS", []) if o.get("Name") == "Linux"), None
+    )
+    if linux_block is None:
+        raise RuntimeError("No 'Linux' OS block in NvidiaGPU/resources.json")
+
+    prefix = f"{TARGET_VGPU_MAJOR}."
+    candidates = {}
+    for distro in linux_block.get("Version", []):
+        for drv_block in distro.get("Driver", []):
+            if drv_block.get("Type") != "GRID":
+                continue
+            for v in drv_block.get("Version", []):
+                vgpu = str(v.get("vGPUVersion", "")).strip()
+                if not vgpu.startswith(prefix):
+                    continue
+                driver_num = v.get("Num")
+                url = v.get("DirLink") or v.get("FwLink")
+                if not driver_num or not url:
+                    continue
+                # Same driver may appear in multiple distro blocks; first wins.
+                candidates.setdefault(driver_num, {"vgpu": vgpu, "url": url})
+
+    if not candidates:
+        raise RuntimeError(
+            f"No vGPU {TARGET_VGPU_MAJOR}.x Linux GRID driver entries found "
+            f"in {RESOURCES_JSON_URL}"
+        )
+
+    best_num = max(
+        candidates,
+        key=lambda n: _vgpu_sort_key(candidates[n]["vgpu"]),
+    )
+    return best_num, candidates[best_num]["url"]
+
+
 def update_driver_config():
     yaml = YAML()
     yaml.preserve_quotes = True
@@ -29,18 +80,15 @@ def update_driver_config():
 
     if not os.path.exists("driver_config.yml"):
         raise FileNotFoundError("driver_config.yml not found in the current directory.")
-    
+
     with open("driver_config.yml", "r") as f:
         config = yaml.load(f)
-    
-    # Get latest version and URL
+
     latest_version, latest_url = get_latest_grid_driver()
-    
-    # Update the grid section while preserving order
+
     config['grid']['version'] = latest_version
     config['grid']['url'] = latest_url
-    
-    # Write back to file
+
     with open("driver_config.yml", "w") as f:
         yaml.dump(config, f)
 


### PR DESCRIPTION
## Why

The previous auto-updater read the deprecated `Nvidia-GPU-Linux-Resources.json`, which HPC stopped updating past **vGPU 17.55 (550.144.06)**. With main now on 570.211.01 (vGPU 18.6, merged in #154), the auto-updater was silently a no-op and would never pick up patches.

## What this does

Switches the source to the live `NvidiaGPU/resources.json` and adds a clear, conservative selection policy:

> Track the **latest patch within the currently-pinned driver major**.

The target major is derived from `driver_config.yml`'s `grid.version` itself — no hardcoded constant.

- `grid.version: 570.211.01` ⇒ target major `570` ⇒ picks the highest `570.x.x` in `resources.json`
- When NVIDIA ships `570.215.xx`, it's picked up automatically
- When `595.x.x` ships, it is **not** auto-bumped (major bumps need validation — kernel-module ABI, install-script behaviour, vGPU licensing all change)
- To intentionally move to a new major (e.g. R580), edit `driver_config.yml` once; the auto-updater follows

## Why driver-major and not vGPU-major

| | vGPU major (18.x) | Driver major (570.x) |
|---|---|---|
| Source of truth | hardcoded constant | `driver_config.yml` |
| ABI-stable boundary | indirectly | directly (this **is** NVIDIA's driver branch identifier) |
| Migrating to next | edit code | edit yml |
| Same behaviour today | ✓ (both map to {570.211.01, 570.195.03}) | ✓ |

## Behaviour today (verified locally)

- Current state: `grid.version=570.211.01` ⇒ target major `570` ⇒ candidates `{570.211.01, 570.195.03}` ⇒ picks `570.211.01` (no-op, idempotent)
- If `grid.version` is hand-set to `595.58.03` ⇒ tracks `595.x` (vGPU 20.x), does not regress to 570

## Other improvements

- `requests.get(..., timeout=30)` to avoid hanging the daily workflow
- `DirLink → FwLink` fallback (the v18.5 entry in `resources.json` only has `FwLink`)
- Numeric sort via tuple-of-ints (so 570.99.10 > 570.99.9, not lex)
- Clear `RuntimeError` if `grid.version` is malformed or the target major has no entries in `resources.json`

## Tested

10 unit-style scenarios run locally — current data, idempotency, 595-series tracking, 550-series tie-breaking, end-to-end `update_driver_config` against the real yml, garbage-input error path, synthetic patch-bump-within-major, numeric-vs-lex sort, and missing-major error. All pass.

The existing `update_grid_driver.yaml` cron workflow needs no changes — `grep '^\+  version: '` on the diff still works.
