### PR TITLE
Skip per-boot update-initramfs when nouveau blacklist is baked into the VHD

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -29,9 +29,21 @@ done
 
 use_package_manager_with_retries wait_for_dpkg_lock install_cached_nvidia_packages 10 3
 
-# blacklist nouveau driver, nvidia driver dependency
-cp /opt/gpu/blacklist-nouveau.conf /etc/modprobe.d/blacklist-nouveau.conf
-update-initramfs -u
+# blacklist nouveau driver, nvidia driver dependency.
+# Rebuilding the initramfs costs ~10-30s at every node boot. When the VHD already baked the
+# nouveau blacklist into its initramfs for THIS exact kernel (AgentBaker writes the marker
+# below), skip the rebuild. Fall back to the full path on any mismatch -- older VHD without the
+# marker, kernel drift between VHD build and node boot, or altered on-disk content -- so the
+# outcome is always correct regardless of VHD/image version skew.
+NOUVEAU_BLACKLIST_MARKER="/opt/azure/aks-gpu/nouveau-blacklist-marker"
+if [ -f "${NOUVEAU_BLACKLIST_MARKER}" ] && \
+   grep -qx "kernel=$(uname -r)" "${NOUVEAU_BLACKLIST_MARKER}" && \
+   cmp -s /opt/gpu/blacklist-nouveau.conf /etc/modprobe.d/blacklist-nouveau.conf; then
+    echo "nouveau blacklist already baked into VHD initramfs for kernel $(uname -r); skipping update-initramfs"
+else
+    cp /opt/gpu/blacklist-nouveau.conf /etc/modprobe.d/blacklist-nouveau.conf
+    update-initramfs -u
+fi
 
 # clean up lingering files from previous install
 set +e


### PR DESCRIPTION
## What
`install.sh` blacklists nouveau and runs `update-initramfs -u` on **every node boot** (~10-30s). This change skips that rebuild when AgentBaker has already baked the nouveau blacklist into the VHD initramfs for the running kernel.

The fast path engages **only** when all of:
- the kernel-gated marker `/opt/azure/aks-gpu/nouveau-blacklist-marker` exists and its `kernel=` line matches `uname -r`, **and**
- the on-disk `/etc/modprobe.d/blacklist-nouveau.conf` is byte-identical (`cmp`) to the image's `/opt/gpu/blacklist-nouveau.conf`.

Any mismatch — older VHD without the marker, kernel drift between VHD build and node boot, or altered content — falls back to the original `cp` + `update-initramfs` path. Backward/forward compatible in both directions.

## Why
GPU provisioning-time reduction. Removes a deterministic ~10-30s boot cost and makes nouveau blacklisted from first boot.

## Cross-repo dependency
The win only materializes once the VHD writes the marker. Pairs with **Azure/AgentBaker** PR (bake nouveau blacklist into the Ubuntu VHD). Draft until that lands and is validated on a VHD build. This PR is safe to ship independently (no marker ⇒ unchanged behavior).