### PR TITLE
chore: update NVIDIA GRID driver to 570.237 (vGPU18.8)

### DIFF
--- a/driver_config.yml
+++ b/driver_config.yml
@@ -7,9 +7,11 @@ cuda_lts:
   version: "580.159.04"
 
 grid:
-  version: "570.211.01"
+  version: "570.237"
   # We do not support GRID drivers on ARM64 architecture.
-  url: "https://download.microsoft.com/download/2a04ca6a-9eec-40d9-9564-9cdea1ab795f/NVIDIA-Linux-x86_64-570.211.01-grid-azure.run"
+  # vGPU18.8 branch driver for NVadsA10_v5. NVIDIA publishes this build as a
+  # two-component version (570.237), not the usual three-component form.
+  url: "https://download.microsoft.com/download/5e213ec5-834f-4b0a-87f7-772751353b06/NVIDIA-Linux-x86_64-570.237-grid-azure.run"
 
 grid_v20:
   version: "595.58.03"


### PR DESCRIPTION
## What

Bumps the GRID driver (used by `NVadsA10_v5` / A10 SKUs) from **570.211.01 → 570.237**, and points `url` at the new Microsoft-hosted runfile.

```yaml
grid:
  version: "570.237"
  url: "https://download.microsoft.com/download/5e213ec5-834f-4b0a-87f7-772751353b06/NVIDIA-Linux-x86_64-570.237-grid-azure.run"
```

## Why the version has only two components

`570.237` looks wrong next to the usual three-component GRID versions (`570.211.01`, `595.58.03`), so I verified it against the runfile itself rather than trusting the filename. The self-extracting header declares:

```
label="NVIDIA Accelerated Graphics Driver for Linux-x86_64 570.237"
version_string=570.237
targetdir=NVIDIA-Linux-x86_64-570.237-grid-azure
```

So the two-component form is how NVIDIA versions this particular vGPU18.8 build — not a truncated value. I added a short comment in `driver_config.yml` recording this so the next person doesn't "fix" it.

## Validation

- **Source of truth** — the [Azure N-series Linux driver setup docs](https://learn.microsoft.com/azure/virtual-machines/linux/n-series-driver-setup) GRID table now lists `NVadsA10_v5 → vGPU18.8 → NVIDIA-Linux-x86_64-570.237-grid-azure.run` with this exact download URL. (The step-by-step `wget` snippet further down that page still shows 570.211.01 — stale docs, the table is the updated one.)
- **URL reachable** — returns HTTP 200.
- **Name derivation is consistent** — `download.sh` and `install.sh` build `RUNFILE="NVIDIA-Linux-x86_64-${DRIVER_VERSION}-grid-azure"`. With `DRIVER_VERSION=570.237` that matches both the URL basename (so the `mv ${RUNFILE}.run` after `curl -O` succeeds) and the runfile's `targetdir` (so `/opt/gpu/${RUNFILE}/nvidia-installer` exists after extraction).
- **No 3-component assumptions anywhere** — `DRIVER_VERSION` is only ever used as an opaque string: runfile name, the DKMS marker `driver_version=` field and its string equality check in `baked_marker_matches`, the buildx cache key, and the image tag. `paulhatch/semantic-version`'s `version_format` receives it as literal text, so the tag becomes `570.237-<timestamp>`. `fabricmanager` version interpolation is CUDA-only and unaffected.
- **YAML parses** and other entries (`cuda`, `cuda_lts`, `grid_v20`) are untouched.

## Heads-up: the daily auto-update may try to revert this

`update_grid_driver.yaml` runs `auto_update.py`, which reads the GRID "Latest" entry from [`azhpc-extensions/Nvidia-GPU-Linux-Resources.json`](https://github.com/Azure/azhpc-extensions/blob/master/NvidiaGPU/Nvidia-GPU-Linux-Resources.json). That feed still reports `570.211.01`, so the nightly job will likely open a PR moving `grid` **back** to 570.211.01 until the feed catches up. It opens a PR rather than pushing directly, so nothing reverts silently — just don't merge that one blindly.


---

## Local build validation

Beyond CI, I ran the equivalent build locally:

```
docker buildx build --platform linux/amd64 \
  --build-arg DRIVER_URL=<new url> --build-arg DRIVER_KIND=grid --build-arg DRIVER_VERSION=570.237 .
```

It completed successfully, and the resulting image contains:

```
/opt/gpu/NVIDIA-Linux-x86_64-570.237-grid-azure/nvidia-installer
.manifest -> 570.237
libnvidia-ml.so.570.237, nvidia-gridd
```

confirming the download, the `mv ${RUNFILE}.run`, and the extraction all resolve correctly from `DRIVER_VERSION=570.237`.

> Supersedes #178, which was identical but opened from a fork. Fork PRs get no repo secrets, so all six build jobs failed instantly on an invalid image tag (unrelated to this change — see #173 for that fix). Reopened from a branch on this repo so CI can actually exercise the build.
